### PR TITLE
SDIT-642 Use synchronise helper for visits create

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsDomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsDomainEventListener.kt
@@ -2,24 +2,25 @@ package uk.gov.justice.digital.hmpps.prisonertonomisupdate.visits
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.microsoft.applicationinsights.TelemetryClient
 import io.awspring.cloud.sqs.annotation.SqsListener
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.EventFeatureSwitch
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.HMPPSDomainEvent
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.SQSMessage
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.DomainEventListener
+import java.util.concurrent.CompletableFuture
 
 @Service
 class VisitsDomainEventListener(
-  private val prisonVisitsService: PrisonVisitsService,
-  private val objectMapper: ObjectMapper,
-  private val eventFeatureSwitch: EventFeatureSwitch,
-  private val telemetryClient: TelemetryClient,
+  private val visitsService: VisitsService,
+  objectMapper: ObjectMapper,
+  eventFeatureSwitch: EventFeatureSwitch,
+) : DomainEventListener(
+  service = visitsService,
+  objectMapper = objectMapper,
+  eventFeatureSwitch = eventFeatureSwitch,
 ) {
 
   private companion object {
@@ -28,38 +29,13 @@ class VisitsDomainEventListener(
 
   @SqsListener("visit", factory = "hmppsQueueContainerFactoryProxy")
   @WithSpan(value = "Digital-Prison-Services-hmpps_prisoner_to_nomis_visit_queue", kind = SpanKind.SERVER)
-  fun onPrisonerChange(message: String) {
-    log.debug("Received visit message {}", message)
-    val sqsMessage: SQSMessage = objectMapper.readValue(message)
-    when (sqsMessage.Type) {
-      "Notification" -> {
-        val (eventType) = objectMapper.readValue<HMPPSDomainEvent>(sqsMessage.Message)
-        if (eventFeatureSwitch.isEnabled(eventType)) {
-          when (eventType) {
-            "prison-visit.booked" -> prisonVisitsService.createVisit(objectMapper.readValue(sqsMessage.Message))
-            "prison-visit.cancelled" -> prisonVisitsService.cancelVisit(objectMapper.readValue(sqsMessage.Message))
-            "prison-visit.changed" -> prisonVisitsService.updateVisit(objectMapper.readValue(sqsMessage.Message))
-            else -> log.info("Received a message I wasn't expecting: {}", eventType)
-          }
-        } else {
-          log.warn("Feature switch is disabled for {}", eventType)
-        }
-      }
+  fun onMessage(rawMessage: String): CompletableFuture<Void> = onDomainEvent(rawMessage) { eventType, message ->
+    when (eventType) {
+      "prison-visit.booked" -> visitsService.createVisit(objectMapper.readValue(message))
+      "prison-visit.cancelled" -> visitsService.cancelVisit(objectMapper.readValue(message))
+      "prison-visit.changed" -> visitsService.updateVisit(objectMapper.readValue(message))
 
-      "RETRY" -> {
-        val context = objectMapper.readValue<VisitContext>(sqsMessage.Message)
-        telemetryClient.trackEvent(
-          "visit-retry-received",
-          mapOf("id" to context.vsipId),
-        )
-
-        prisonVisitsService.createVisitRetry(context)
-
-        telemetryClient.trackEvent(
-          "visit-retry-success",
-          mapOf("id" to context.vsipId),
-        )
-      }
+      else -> log.info("Received a message I wasn't expecting: {}", eventType)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsService.kt
@@ -78,7 +78,12 @@ class VisitsService(
   fun retryCreateVisitMapping(context: CreateMappingRetryMessage<VisitMapping>) {
     mappingService.createMapping(
       VisitMappingDto(nomisId = context.mapping.nomisId, vsipId = context.mapping.vsipId, mappingType = "ONLINE"),
-    )
+    ).also {
+      telemetryClient.trackEvent(
+        "visit-retry-success",
+        mapOf("id" to context.mapping.vsipId, "nomisId" to context.mapping.nomisId),
+      )
+    }
   }
 
   override suspend fun retryCreateMapping(message: String) = retryCreateVisitMapping(message.fromJson())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsUpdateQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsUpdateQueueService.kt
@@ -3,37 +3,20 @@ package uk.gov.justice.digital.hmpps.prisonertonomisupdate.visits
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Service
-import software.amazon.awssdk.services.sqs.model.SendMessageRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.SQSMessage
-import uk.gov.justice.hmpps.sqs.HmppsQueue
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.RetryQueueService
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Service
 class VisitsUpdateQueueService(
-  private val hmppsQueueService: HmppsQueueService,
-  private val telemetryClient: TelemetryClient,
-  private val objectMapper: ObjectMapper,
-) {
-  private val prisonerQueue by lazy { hmppsQueueService.findByQueueId("visit") as HmppsQueue }
-  private val sqsClient by lazy { prisonerQueue.sqsClient }
-  private val queueUrl by lazy { prisonerQueue.queueUrl }
+  hmppsQueueService: HmppsQueueService,
+  telemetryClient: TelemetryClient,
+  objectMapper: ObjectMapper,
+) :
+  RetryQueueService(
+    queueId = "visit",
+    hmppsQueueService = hmppsQueueService,
+    telemetryClient = telemetryClient,
+    objectMapper = objectMapper,
+  )
 
-  fun sendMessage(context: VisitContext) {
-    val sqsMessage = SQSMessage(
-      Type = "RETRY",
-      Message = objectMapper.writeValueAsString(context),
-      MessageId = "retry-${context.vsipId}",
-    )
-    val result = sqsClient.sendMessage(
-      SendMessageRequest.builder().queueUrl(queueUrl).messageBody(objectMapper.writeValueAsString(sqsMessage)).build(),
-    ).get()
-
-    telemetryClient.trackEvent(
-      "create-visit-map-queue-retry",
-      mapOf("messageId" to result.messageId()!!, "id" to context.vsipId),
-    )
-  }
-}
-
-data class VisitContext(val nomisId: String, val vsipId: String)
+data class VisitMapping(val nomisId: String, val vsipId: String)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/helpers/Messages.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/helpers/Messages.kt
@@ -32,11 +32,10 @@ fun prisonVisitCreatedMessage(
         "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem"}      
 """.trimIndent()
 
-fun retryMessage() = """
+fun retryVisitsCreateMappingMessage() = """
       {
-        "Type":"RETRY",
-        "Message":"{\"nomisId\":\"12345\",\"vsipId\":\"12\"}",
-        "MessageId":"retry-12"
+        "Type":"RETRY_CREATE_MAPPING",
+        "Message":"{\"mapping\": {\"nomisId\":\"12345\",\"vsipId\":\"12\"}}",        "MessageId":"retry-12"
       }
 """.trimIndent()
 
@@ -85,8 +84,7 @@ fun activityCreatedMessage(identifier: Long) = """
 fun activityRetryMessage() = """
       {
         "Type":"RETRY_CREATE_MAPPING",
-        "Message":"{\"mapping\": {\"activityScheduleId\":12345,\"nomisCourseActivityId\":15}, \"telemetryAttributes\": {}}",
-        "MessageId":"retry-15"
+        "Message":"{\"mapping\": {\"activityScheduleId\":12345,\"nomisCourseActivityId\":15}, \"telemetryAttributes\": {}}"
       }
 """.trimIndent()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/helpers/Messages.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/helpers/Messages.kt
@@ -35,7 +35,7 @@ fun prisonVisitCreatedMessage(
 fun retryVisitsCreateMappingMessage() = """
       {
         "Type":"RETRY_CREATE_MAPPING",
-        "Message":"{\"mapping\": {\"nomisId\":\"12345\",\"vsipId\":\"12\"}}",        "MessageId":"retry-12"
+        "Message":"{\"mapping\": {\"nomisId\":\"12345\",\"vsipId\":\"12\"}}"
       }
 """.trimIndent()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsDomainEventsListenerTest.kt
@@ -13,7 +13,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.objectMapper
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.prisonVisitCreatedMessage
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.retryMessage
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.retryVisitsCreateMappingMessage
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.EventFeatureSwitch
 import java.time.LocalDate
 
@@ -45,7 +45,7 @@ internal class VisitsDomainEventsListenerTest {
             visitId = "99",
             occurredAt = "2021-03-08T11:23:56.031Z",
           ),
-        )
+        ).join()
 
         verify(visitsService).createVisit(
           org.mockito.kotlin.check {
@@ -70,7 +70,7 @@ internal class VisitsDomainEventsListenerTest {
             visitId = "99",
             occurredAt = "2021-03-08T11:23:56.031Z",
           ),
-        )
+        ).join()
 
         verifyNoInteractions(visitsService)
       }
@@ -80,7 +80,7 @@ internal class VisitsDomainEventsListenerTest {
     inner class Retries {
       @Test
       internal fun `will call retry service with visit context data`() = runBlocking {
-        listener.onMessage(rawMessage = retryMessage())
+        listener.onMessage(rawMessage = retryVisitsCreateMappingMessage()).join()
 
         verify(visitsService).retryCreateMapping(any())
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsDomainEventsListenerTest.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.visits
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.microsoft.applicationinsights.TelemetryClient
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -20,17 +18,15 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.EventFeature
 import java.time.LocalDate
 
 internal class VisitsDomainEventsListenerTest {
-  private val prisonVisitsService: PrisonVisitsService = mock()
+  private val visitsService: VisitsService = mock()
   private val objectMapper: ObjectMapper = objectMapper()
   private val eventFeatureSwitch: EventFeatureSwitch = mock()
-  private val telemetryClient: TelemetryClient = mock()
 
   private val listener =
     VisitsDomainEventListener(
-      prisonVisitsService,
+      visitsService,
       objectMapper,
       eventFeatureSwitch,
-      telemetryClient,
     )
 
   @Nested
@@ -43,15 +39,15 @@ internal class VisitsDomainEventsListenerTest {
       }
 
       @Test
-      internal fun `will call service with create visit data`() {
-        listener.onPrisonerChange(
-          message = prisonVisitCreatedMessage(
+      internal fun `will call service with create visit data`() = runBlocking {
+        listener.onMessage(
+          rawMessage = prisonVisitCreatedMessage(
             visitId = "99",
             occurredAt = "2021-03-08T11:23:56.031Z",
           ),
         )
 
-        verify(prisonVisitsService).createVisit(
+        verify(visitsService).createVisit(
           org.mockito.kotlin.check {
             Assertions.assertThat(it.reference).isEqualTo("99")
             Assertions.assertThat(it.bookingDate).isEqualTo(LocalDate.parse("2021-03-08"))
@@ -69,37 +65,24 @@ internal class VisitsDomainEventsListenerTest {
 
       @Test
       internal fun `will not call service`() {
-        listener.onPrisonerChange(
-          message = prisonVisitCreatedMessage(
+        listener.onMessage(
+          rawMessage = prisonVisitCreatedMessage(
             visitId = "99",
             occurredAt = "2021-03-08T11:23:56.031Z",
           ),
         )
 
-        verifyNoInteractions(prisonVisitsService)
+        verifyNoInteractions(visitsService)
       }
     }
 
     @Nested
     inner class Retries {
       @Test
-      internal fun `will call retry service with visit context data`() {
-        listener.onPrisonerChange(message = retryMessage())
+      internal fun `will call retry service with visit context data`() = runBlocking {
+        listener.onMessage(rawMessage = retryMessage())
 
-        verify(prisonVisitsService).createVisitRetry(
-          org.mockito.kotlin.check {
-            Assertions.assertThat(it.vsipId).isEqualTo("12")
-            Assertions.assertThat(it.nomisId).isEqualTo("12345")
-          },
-        )
-
-        verify(telemetryClient).trackEvent(
-          eq("visit-retry-received"),
-          org.mockito.kotlin.check {
-            Assertions.assertThat(it["id"]).isEqualTo("12")
-          },
-          isNull(),
-        )
+        verify(visitsService).retryCreateMapping(any())
       }
     }
   }


### PR DESCRIPTION
What we lose:

1. Telemetry on failures - rely on DLQ and exceptions
2. Some telemetry attributes on a duplicate domain event (we don't bother reading a visit if it detected as a duplicate event so no times etc added to telemetry 