### PR TITLE
SDIT-642 Use synchronise helper for incentives create

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesDomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesDomainEventListener.kt
@@ -1,25 +1,25 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.incentives
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
-import com.microsoft.applicationinsights.TelemetryClient
 import io.awspring.cloud.sqs.annotation.SqsListener
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.EventFeatureSwitch
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.HMPPSDomainEvent
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.SQSMessage
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.DomainEventListener
+import java.util.concurrent.CompletableFuture
 
 @Service
 class IncentivesDomainEventListener(
   private val incentivesService: IncentivesService,
-  private val objectMapper: ObjectMapper,
-  private val eventFeatureSwitch: EventFeatureSwitch,
-  private val telemetryClient: TelemetryClient,
+  objectMapper: ObjectMapper,
+  eventFeatureSwitch: EventFeatureSwitch,
+) : DomainEventListener(
+  service = incentivesService,
+  objectMapper = objectMapper,
+  eventFeatureSwitch = eventFeatureSwitch,
 ) {
 
   private companion object {
@@ -28,36 +28,10 @@ class IncentivesDomainEventListener(
 
   @SqsListener("incentive", factory = "hmppsQueueContainerFactoryProxy")
   @WithSpan(value = "Digital-Prison-Services-hmpps_prisoner_to_nomis_incentive_queue", kind = SpanKind.SERVER)
-  fun onPrisonerChange(message: String) {
-    log.debug("Received incentive message {}", message)
-    val sqsMessage: SQSMessage = objectMapper.readValue(message)
-    when (sqsMessage.Type) {
-      "Notification" -> {
-        val (eventType) = objectMapper.readValue<HMPPSDomainEvent>(sqsMessage.Message)
-        if (eventFeatureSwitch.isEnabled(eventType)) {
-          when (eventType) {
-            "incentives.iep-review.inserted" -> incentivesService.createIncentive(objectMapper.readValue(sqsMessage.Message))
-            else -> log.info("Received a message I wasn't expecting: {}", eventType)
-          }
-        } else {
-          log.warn("Feature switch is disabled for {}", eventType)
-        }
-      }
-
-      "RETRY" -> {
-        val context = objectMapper.readValue<IncentiveContext>(sqsMessage.Message)
-        telemetryClient.trackEvent(
-          "incentive-retry-received",
-          mapOf("id" to context.incentiveId.toString()),
-        )
-
-        incentivesService.createIncentiveRetry(context)
-
-        telemetryClient.trackEvent(
-          "incentive-retry-success",
-          mapOf("id" to context.incentiveId.toString()),
-        )
-      }
+  fun onMessage(rawMessage: String): CompletableFuture<Void> = onDomainEvent(rawMessage) { eventType, message ->
+    when (eventType) {
+      "incentives.iep-review.inserted" -> incentivesService.createIncentive(message.fromJson())
+      else -> log.info("Received a message I wasn't expecting: {}", eventType)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesService.kt
@@ -1,12 +1,14 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.incentives
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.microsoft.applicationinsights.TelemetryClient
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.CreateIncentiveDto
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.CreateMappingRetryMessage
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.CreateMappingRetryable
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.synchronise
 import java.time.format.DateTimeFormatter
 
 private const val incentiveCreatedInNomsByUser = "USER_CREATED_NOMIS"
@@ -18,11 +20,8 @@ class IncentivesService(
   private val mappingService: IncentivesMappingService,
   private val incentivesUpdateQueueService: IncentivesUpdateQueueService,
   private val telemetryClient: TelemetryClient,
-) {
-
-  private companion object {
-    val log: Logger = LoggerFactory.getLogger(this::class.java)
-  }
+  private val objectMapper: ObjectMapper,
+) : CreateMappingRetryable {
 
   private fun IepDetail.toNomisIncentive(): CreateIncentiveDto = CreateIncentiveDto(
     comments = comments,
@@ -32,75 +31,57 @@ class IncentivesService(
     iepLevel = iepCode,
   )
 
-  fun createIncentive(event: IncentiveCreatedEvent) {
-    incentivesApiService.getIncentive(event.additionalInformation.id).run {
-      val telemetryMap = mutableMapOf<String, String>(
-        "offenderNo" to prisonerNumber!!,
-        "prisonId" to agencyId,
-        "id" to id.toString(),
-        "iep" to iepCode,
-        "iepDate" to iepDate.format(DateTimeFormatter.ISO_DATE),
-        "iepTime" to iepTime.format(DateTimeFormatter.ISO_TIME),
+  suspend fun createIncentive(event: IncentiveCreatedEvent) {
+    synchronise {
+      name = "incentive"
+      telemetryClient = this@IncentivesService.telemetryClient
+      retryQueueService = incentivesUpdateQueueService
+      eventTelemetry = mapOf(
+        "id" to event.additionalInformation.id.toString(),
+        "offenderNo" to (event.additionalInformation.nomsNumber ?: "unknown"),
       )
 
-      if (event.additionalInformation.reason == incentiveCreatedInNomsByUser) {
-        log.debug("Incentive id $event.additionalInformation.id created in NOMIS so ignoring")
-        return
+      checkMappingDoesNotExist {
+        mappingService.getMappingGivenIncentiveId(event.additionalInformation.id)
       }
-
-      // to protect against repeated create messages for same incentive
-      if (mappingService.getMappingGivenIncentiveId(event.additionalInformation.id) != null) {
-        log.warn("Mapping already exists for incentive id $event.additionalInformation.id")
-        return
+      transform {
+        incentivesApiService.getIncentive(event.additionalInformation.id)
+          .takeUnless { event.additionalInformation.reason == incentiveCreatedInNomsByUser }?.let { incentive ->
+            eventTelemetry += mapOf(
+              "prisonId" to incentive.agencyId,
+              "iep" to incentive.iepCode,
+              "iepDate" to incentive.iepDate.format(DateTimeFormatter.ISO_DATE),
+              "iepTime" to incentive.iepTime.format(DateTimeFormatter.ISO_TIME),
+            )
+            nomisApiService.createIncentive(
+              incentive.bookingId,
+              incentive.toNomisIncentive(),
+            ).let { nomisResponse ->
+              IncentiveMappingDto(
+                nomisBookingId = nomisResponse.bookingId,
+                nomisIncentiveSequence = nomisResponse.sequence.toInt(),
+                incentiveId = event.additionalInformation.id,
+                mappingType = "INCENTIVE_CREATED",
+              )
+            }
+          }
       }
-
-      val nomisResponse = try {
-        nomisApiService.createIncentive(this.bookingId, this.toNomisIncentive())
-      } catch (e: Exception) {
-        telemetryClient.trackEvent("incentive-create-failed", telemetryMap)
-        log.error("createIncentive() Unexpected exception", e)
-        throw e
-      }
-
-      telemetryMap["nomisBookingId"] = nomisResponse.bookingId.toString()
-      telemetryMap["nomisIncentiveSequence"] = nomisResponse.sequence.toString()
-
-      try {
-        mappingService.createMapping(
-          IncentiveMappingDto(
-            nomisBookingId = nomisResponse.bookingId,
-            nomisIncentiveSequence = nomisResponse.sequence.toInt(),
-            incentiveId = event.additionalInformation.id,
-            mappingType = "INCENTIVE_CREATED",
-          ),
-        )
-      } catch (e: Exception) {
-        telemetryClient.trackEvent("incentive-create-map-failed", telemetryMap)
-        log.error("Unexpected exception, queueing retry", e)
-        incentivesUpdateQueueService.sendMessage(
-          IncentiveContext(
-            nomisBookingId = nomisResponse.bookingId,
-            nomisIncentiveSequence = nomisResponse.sequence.toInt(),
-            incentiveId = event.additionalInformation.id,
-          ),
-        )
-        return
-      }
-
-      telemetryClient.trackEvent("incentive-created-event", telemetryMap)
+      saveMapping { mappingService.createMapping(it) }
     }
   }
 
-  fun createIncentiveRetry(context: IncentiveContext) {
+  fun retryCreateIncentiveMapping(context: CreateMappingRetryMessage<IncentiveMapping>) {
     mappingService.createMapping(
       IncentiveMappingDto(
-        nomisBookingId = context.nomisBookingId,
-        nomisIncentiveSequence = context.nomisIncentiveSequence,
-        incentiveId = context.incentiveId,
+        nomisBookingId = context.mapping.nomisBookingId,
+        nomisIncentiveSequence = context.mapping.nomisIncentiveSequence,
+        incentiveId = context.mapping.incentiveId,
         mappingType = "INCENTIVE_CREATED",
       ),
     )
   }
+
+  override suspend fun retryCreateMapping(message: String) = retryCreateIncentiveMapping(message.fromJson())
 
   data class AdditionalInformation(
     val id: Long,
@@ -111,4 +92,7 @@ class IncentivesService(
   data class IncentiveCreatedEvent(
     val additionalInformation: AdditionalInformation,
   )
+
+  private inline fun <reified T> String.fromJson(): T =
+    objectMapper.readValue(this)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesService.kt
@@ -78,7 +78,13 @@ class IncentivesService(
         incentiveId = context.mapping.incentiveId,
         mappingType = "INCENTIVE_CREATED",
       ),
-    )
+    ).also {
+      telemetryClient.trackEvent(
+        "incentive-retry-success",
+        mapOf("id" to context.mapping.toString()),
+        null,
+      )
+    }
   }
 
   override suspend fun retryCreateMapping(message: String) = retryCreateIncentiveMapping(message.fromJson())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesUpdateQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesUpdateQueueService.kt
@@ -3,37 +3,20 @@ package uk.gov.justice.digital.hmpps.prisonertonomisupdate.incentives
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Service
-import software.amazon.awssdk.services.sqs.model.SendMessageRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.SQSMessage
-import uk.gov.justice.hmpps.sqs.HmppsQueue
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.RetryQueueService
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Service
 class IncentivesUpdateQueueService(
-  private val hmppsQueueService: HmppsQueueService,
-  private val telemetryClient: TelemetryClient,
-  private val objectMapper: ObjectMapper,
-) {
-  private val queue by lazy { hmppsQueueService.findByQueueId("incentive") as HmppsQueue }
-  private val sqsClient by lazy { queue.sqsClient }
-  private val queueUrl by lazy { queue.queueUrl }
+  hmppsQueueService: HmppsQueueService,
+  telemetryClient: TelemetryClient,
+  objectMapper: ObjectMapper,
+) :
+  RetryQueueService(
+    queueId = "incentive",
+    hmppsQueueService = hmppsQueueService,
+    telemetryClient = telemetryClient,
+    objectMapper = objectMapper,
+  )
 
-  fun sendMessage(context: IncentiveContext) {
-    val sqsMessage = SQSMessage(
-      Type = "RETRY",
-      Message = objectMapper.writeValueAsString(context),
-      MessageId = "retry-${context.incentiveId}",
-    )
-    val result = sqsClient.sendMessage(
-      SendMessageRequest.builder().queueUrl(queueUrl).messageBody(objectMapper.writeValueAsString(sqsMessage)).build(),
-    ).get()
-
-    telemetryClient.trackEvent(
-      "create-incentive-map-queue-retry",
-      mapOf("messageId" to result.messageId()!!, "id" to context.incentiveId.toString()),
-    )
-  }
-}
-
-data class IncentiveContext(val nomisBookingId: Long, val nomisIncentiveSequence: Int, val incentiveId: Long)
+data class IncentiveMapping(val nomisBookingId: Long, val nomisIncentiveSequence: Int, val incentiveId: Long)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/helpers/Messages.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/helpers/Messages.kt
@@ -58,9 +58,8 @@ fun incentiveCreatedMessage(incentiveId: Long) = """
 
 fun incentiveRetryMessage() = """
       {
-        "Type":"RETRY",
-        "Message":"{\"nomisBookingId\":12345,\"nomisIncentiveSequence\":2,\"incentiveId\":15}",
-        "MessageId":"retry-15"
+        "Type":"RETRY_CREATE_MAPPING",
+        "Message":"{\"mapping\": {\"nomisBookingId\":12345,\"nomisIncentiveSequence\":2,\"incentiveId\":15}}"
       }
 """.trimIndent()
 


### PR DESCRIPTION
What we lose:

- Custom event when create fails, rely on DLQ and exception logging