### PR TITLE
SAA-1162: Update activities-api-docs.json and related usage

### DIFF
--- a/openapi-specs/activities-api-docs.json
+++ b/openapi-specs/activities-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2023-08-24.10219.d31670f"
+    "version": "2023-09-12"
   },
   "servers": [
     {
@@ -65,8 +65,11 @@
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "204": {
+            "description": "One or more prisoners were deallocated from the schedule."
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -75,8 +78,8 @@
               }
             }
           },
-          "404": {
-            "description": "The activity schedule for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -95,11 +98,8 @@
               }
             }
           },
-          "204": {
-            "description": "One or more prisoners were deallocated from the schedule."
-          },
-          "400": {
-            "description": "Bad request",
+          "404": {
+            "description": "The activity schedule for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -141,8 +141,11 @@
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "204": {
+            "description": "The scheduled instance was successfully un cancelled."
+          },
+          "400": {
+            "description": "The scheduled instance is not cancelled or it is in the past",
             "content": {
               "application/json": {
                 "schema": {
@@ -151,8 +154,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found, the scheduled instance does not exist",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -171,8 +174,8 @@
               }
             }
           },
-          "400": {
-            "description": "The scheduled instance is not cancelled or it is in the past",
+          "404": {
+            "description": "Not Found, the scheduled instance does not exist",
             "content": {
               "application/json": {
                 "schema": {
@@ -180,9 +183,6 @@
                 }
               }
             }
-          },
-          "204": {
-            "description": "The scheduled instance was successfully un cancelled."
           }
         }
       }
@@ -217,26 +217,6 @@
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "204": {
             "description": "Scheduled instance successfully cancelled",
             "content": {
@@ -249,6 +229,26 @@
           },
           "400": {
             "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -410,17 +410,17 @@
         }
       }
     },
-    "/appointment-occurrences/{appointmentOccurrenceId}/cancel": {
+    "/appointments/{appointmentId}/cancel": {
       "put": {
         "tags": [
-          "appointment-occurrence-controller"
+          "appointment-controller"
         ],
-        "summary": "Cancel an appointment occurrence or series of appointment occurrences",
-        "description": "\n    Cancel an appointment occurrence or series of appointment occurrences based on the applyTo property.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "cancelAppointmentOccurrence",
+        "summary": "Cancel an appointment or series of appointments",
+        "description": "\n    Cancel an appointment or series of appointments based on the applyTo property.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "cancelAppointment",
         "parameters": [
           {
-            "name": "appointmentOccurrenceId",
+            "name": "appointmentId",
             "in": "path",
             "required": true,
             "schema": {
@@ -444,19 +444,19 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AppointmentOccurrenceCancelRequest"
+                "$ref": "#/components/schemas/AppointmentCancelRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "202": {
+            "description": "The appointment or series of appointments was cancelled.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/AppointmentSeries"
                 }
               }
             }
@@ -471,18 +471,18 @@
               }
             }
           },
-          "202": {
-            "description": "The appointment occurrence or series of appointment occurrences was cancelled.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Appointment"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "404": {
-            "description": "The appointment occurrence for this ID was not found.",
+            "description": "The appointment for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -534,18 +534,21 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "200": {
+            "description": "The allocations for an activity schedule",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Allocation"
+                  }
                 }
               }
             }
           },
-          "404": {
-            "description": "Schedule ID not found",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -564,15 +567,12 @@
               }
             }
           },
-          "200": {
-            "description": "The allocations for an activity schedule",
+          "404": {
+            "description": "Schedule ID not found",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Allocation"
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -608,32 +608,32 @@
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The activity schedule for this ID was not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "204": {
             "description": "The allocation was created and added to the schedule.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -648,8 +648,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "404": {
+            "description": "The activity schedule for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -724,8 +724,18 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Requested resource not found",
+          "200": {
+            "description": "Successful call - zero or more scheduled events found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrisonerScheduledEvents"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": {
@@ -744,16 +754,6 @@
               }
             }
           },
-          "200": {
-            "description": "Successful call - zero or more scheduled events found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PrisonerScheduledEvents"
-                }
-              }
-            }
-          },
           "403": {
             "description": "Forbidden, requires an appropriate role",
             "content": {
@@ -764,8 +764,8 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -834,8 +834,18 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "Requested resource not found",
+          "200": {
+            "description": "Successful call - zero or more scheduled events found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrisonerScheduledEvents"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": {
@@ -854,16 +864,6 @@
               }
             }
           },
-          "200": {
-            "description": "Successful call - zero or more scheduled events found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PrisonerScheduledEvents"
-                }
-              }
-            }
-          },
           "403": {
             "description": "Forbidden, requires an appropriate role",
             "content": {
@@ -874,8 +874,8 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -929,16 +929,6 @@
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "The allocations for the prisoners",
             "content": {
@@ -948,6 +938,16 @@
                   "items": {
                     "$ref": "#/components/schemas/PrisonerAllocations"
                   }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1046,6 +1046,16 @@
           "required": true
         },
         "responses": {
+          "200": {
+            "description": "The activity was migrated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityMigrateResponse"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad request",
             "content": {
@@ -1075,16 +1085,6 @@
                 }
               }
             }
-          },
-          "200": {
-            "description": "The activity was migrated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActivityMigrateResponse"
-                }
-              }
-            }
           }
         }
       }
@@ -1094,8 +1094,8 @@
         "tags": [
           "migrate-appointment-controller"
         ],
-        "summary": "Create an appointment or series of appointment occurrences",
-        "description": "\n    Create an appointment or series of appointment occurrences and allocate the supplied prisoner or prisoners to them.\n    \n\nRequires one of the following roles:\n* NOMIS_APPOINTMENTS",
+        "summary": "Migrate an appointment from NOMIS",
+        "description": "\n    Migrate an appointment creating an appointment series with one appointment that has the supplied prisoner allocated.\n    \n\nRequires one of the following roles:\n* NOMIS_APPOINTMENTS",
         "operationId": "migrateAppointment",
         "requestBody": {
           "content": {
@@ -1108,8 +1108,18 @@
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "201": {
+            "description": "The appointment was migrated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentInstance"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1118,18 +1128,8 @@
               }
             }
           },
-          "201": {
-            "description": "The appointment or series of appointment occurrences was created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Appointment"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -1268,8 +1268,18 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "Requested resource not found",
+          "204": {
+            "description": "The event IDS were acknowledged.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
             "content": {
               "application/json": {
                 "schema": {
@@ -1298,83 +1308,8 @@
               }
             }
           },
-          "204": {
-            "description": "The event IDS were acknowledged.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request body",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/bulk-appointments": {
-      "post": {
-        "tags": [
-          "bulk-appointment-controller"
-        ],
-        "summary": "Bulk create a set of appointments",
-        "description": "\n    Create a list of appointments and allocate the supplied prisoner or prisoners to them.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "bulkCreateAppointment",
-        "parameters": [
-          {
-            "name": "Caseload-Id",
-            "in": "header",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkAppointmentsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "The appointments were created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkAppointment"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1436,22 +1371,22 @@
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Search performed successfully",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LocalAuditSearchResults"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1469,79 +1404,14 @@
         }
       }
     },
-    "/appointments": {
+    "/appointments/{prisonCode}/search": {
       "post": {
         "tags": [
           "appointment-controller"
         ],
-        "summary": "Create an appointment or series of appointment occurrences",
-        "description": "\n    Create an appointment or series of appointment occurrences and allocate the supplied prisoner or prisoners to them.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "createAppointment",
-        "parameters": [
-          {
-            "name": "Caseload-Id",
-            "in": "header",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AppointmentCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "The appointment or series of appointment occurrences was created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Appointment"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/appointment-occurrences/{prisonCode}/search": {
-      "post": {
-        "tags": [
-          "appointment-occurrence-controller"
-        ],
-        "summary": "Search for appointment occurrences within the specified prison",
-        "description": "\n    Uses the supplied prison code and search parameters to filter and return appointment occurrence search results.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "searchAppointmentOccurrences",
+        "summary": "Search for appointments within the specified prison",
+        "description": "\n    Uses the supplied prison code and search parameters to filter and return appointment search results.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "searchAppointments",
         "parameters": [
           {
             "name": "prisonCode",
@@ -1567,13 +1437,36 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AppointmentOccurrenceSearchRequest"
+                "$ref": "#/components/schemas/AppointmentSearchRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
+          "202": {
+            "description": "Prison code and search parameters were accepted and results returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AppointmentSearchResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -1583,22 +1476,129 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/appointment-set": {
+      "post": {
+        "tags": [
+          "appointment-set-controller"
+        ],
+        "summary": "Create a set of appointments",
+        "description": "\n    Create a set of appointments that start on the same day and add the associated prisoner as the appointment attendee.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "createAppointmentSet",
+        "parameters": [
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppointmentSetCreateRequest"
+              }
+            }
           },
-          "202": {
-            "description": "Prison code and search parameters were accepted and results returned.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "The appointment set was created.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AppointmentOccurrenceSearchResult"
-                  }
+                  "$ref": "#/components/schemas/AppointmentSet"
                 }
               }
             }
           },
           "400": {
             "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appointment-series": {
+      "post": {
+        "tags": [
+          "appointment-series-controller"
+        ],
+        "summary": "Create an appointment series with one or more appointments",
+        "description": "\n    Create an appointment series with one or more appointments and add the supplied prisoner or prisoners as appointment attendees.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "createAppointmentSeries",
+        "parameters": [
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppointmentSeriesCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "The appointment series was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSeries"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -1650,6 +1650,26 @@
           "required": true
         },
         "responses": {
+          "204": {
+            "description": "The waiting list entry was created and added to the schedule.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -1672,26 +1692,6 @@
           },
           "404": {
             "description": "The activity schedule in the request for this ID was not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "204": {
-            "description": "The waiting list entry was created and added to the schedule.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1745,6 +1745,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -1757,16 +1767,6 @@
           },
           "403": {
             "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1809,18 +1809,18 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "200": {
+            "description": "Waiting list application found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/WaitingListApplication"
                 }
               }
             }
           },
-          "404": {
-            "description": "The waiting list application for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -1839,12 +1839,12 @@
               }
             }
           },
-          "200": {
-            "description": "Waiting list application found",
+          "404": {
+            "description": "The waiting list application for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WaitingListApplication"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1890,8 +1890,38 @@
           "required": true
         },
         "responses": {
+          "202": {
+            "description": "The updated waiting list application.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WaitingListApplication"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -1909,19 +1939,53 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/appointments/{appointmentId}": {
+      "get": {
+        "tags": [
+          "appointment-controller"
+        ],
+        "summary": "Get an appointment by its id",
+        "description": "Returns an appointment with its properties and references to NOMIS by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentById",
+        "parameters": [
+          {
+            "name": "appointmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
-          "202": {
-            "description": "The updated waiting list application.",
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Appointment found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WaitingListApplication"
+                  "$ref": "#/components/schemas/Appointment"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -1930,8 +1994,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "404": {
+            "description": "The appointment for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1941,19 +2005,17 @@
             }
           }
         }
-      }
-    },
-    "/appointment-occurrences/{appointmentOccurrenceId}": {
+      },
       "patch": {
         "tags": [
-          "appointment-occurrence-controller"
+          "appointment-controller"
         ],
-        "summary": "Update an appointment occurrence or series of appointment occurrences",
-        "description": "\n    Update an appointment occurrence or series of appointment occurrences based on the applyTo property.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "updateAppointmentOccurrence",
+        "summary": "Update an appointment or series of appointments",
+        "description": "\n    Update an appointment or series of appointments based on the applyTo property.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "updateAppointment",
         "parameters": [
           {
-            "name": "appointmentOccurrenceId",
+            "name": "appointmentId",
             "in": "path",
             "required": true,
             "schema": {
@@ -1977,19 +2039,19 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AppointmentOccurrenceUpdateRequest"
+                "$ref": "#/components/schemas/AppointmentUpdateRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "202": {
+            "description": "The appointment or series of appointments was updated.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/AppointmentSeries"
                 }
               }
             }
@@ -2004,18 +2066,18 @@
               }
             }
           },
-          "202": {
-            "description": "The appointment occurrence or series of appointment occurrences was updated.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Appointment"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "404": {
-            "description": "The appointment occurrence for this ID was not found.",
+            "description": "The appointment for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2065,6 +2127,26 @@
           "required": true
         },
         "responses": {
+          "202": {
+            "description": "The allocation was updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Allocation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -2085,28 +2167,8 @@
               }
             }
           },
-          "202": {
-            "description": "The allocation was updated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Allocation"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Allocation ID not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -2167,8 +2229,18 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "Activity ID not found",
+          "202": {
+            "description": "The activity was updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Activity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -2197,18 +2269,8 @@
               }
             }
           },
-          "202": {
-            "description": "The activity was updated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Activity"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
+          "404": {
+            "description": "Activity ID not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2300,7 +2362,7 @@
           "activity-schedule-controller"
         ],
         "summary": "Get an activity schedule by its id",
-        "description": "Returns a single activity schedule by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "description": "Returns a single activity schedule by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN\n* NOMIS_ACTIVITIES",
         "operationId": "getScheduleId",
         "parameters": [
           {
@@ -2325,18 +2387,18 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "200": {
+            "description": "Activity found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ActivitySchedule"
                 }
               }
             }
           },
-          "404": {
-            "description": "The activity for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -2355,12 +2417,12 @@
               }
             }
           },
-          "200": {
-            "description": "Activity found",
+          "404": {
+            "description": "The activity for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActivitySchedule"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2399,18 +2461,21 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "200": {
+            "description": "The waiting list applications for an activity schedule",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WaitingListApplication"
+                  }
                 }
               }
             }
           },
-          "404": {
-            "description": "Schedule ID not found",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -2429,15 +2494,12 @@
               }
             }
           },
-          "200": {
-            "description": "The waiting list applications for an activity schedule",
+          "404": {
+            "description": "Schedule ID not found",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/WaitingListApplication"
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2474,8 +2536,18 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "200": {
+            "description": "Candidate suitability details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllocationSuitability"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -2484,8 +2556,8 @@
               }
             }
           },
-          "404": {
-            "description": "The activity schedule for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -2504,18 +2576,8 @@
               }
             }
           },
-          "200": {
-            "description": "Candidate suitability details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AllocationSuitability"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
+          "404": {
+            "description": "The activity schedule for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2630,16 +2692,6 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "A paginated list of candidates was returned.",
             "content": {
@@ -2650,8 +2702,18 @@
               }
             }
           },
-          "404": {
-            "description": "The activity schedule for this ID was not found.",
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -2670,8 +2732,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "404": {
+            "description": "The activity schedule for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2689,7 +2751,7 @@
           "scheduled-instance-controller"
         ],
         "summary": "Get a scheduled instance by ID",
-        "description": "Returns a scheduled instance.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "description": "Returns a scheduled instance.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN\n* NOMIS_ACTIVITIES",
         "operationId": "getScheduledInstanceById",
         "parameters": [
           {
@@ -2714,6 +2776,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Scheduled instance found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityScheduleInstance"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -2730,16 +2802,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Scheduled instance found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActivityScheduleInstance"
                 }
               }
             }
@@ -2777,16 +2839,6 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Attendance records found",
             "content": {
@@ -2796,6 +2848,16 @@
                   "items": {
                     "$ref": "#/components/schemas/Attendance"
                   }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2842,22 +2904,22 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Prison rollout plan found",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RolloutPrisonPlan"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2970,6 +3032,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Successful call - zero or more scheduled instance records found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityScheduleInstance"
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -2986,19 +3061,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Successful call - zero or more scheduled instance records found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivityScheduleInstance"
-                  }
                 }
               }
             }
@@ -3059,6 +3121,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Activity schedules found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivitySchedule"
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -3075,19 +3150,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Activity schedules found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivitySchedule"
-                  }
                 }
               }
             }
@@ -3193,6 +3255,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Locations found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InternalLocation"
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -3209,19 +3284,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Locations found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/InternalLocation"
-                  }
                 }
               }
             }
@@ -3257,6 +3319,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Activities within the category",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityLite"
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -3283,19 +3358,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Activities within the category",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivityLite"
-                  }
                 }
               }
             }
@@ -3331,6 +3393,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Activities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivitySummary"
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -3347,19 +3422,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Activities",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivitySummary"
-                  }
                 }
               }
             }
@@ -3386,18 +3448,18 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "200": {
+            "description": "Prison regime found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/PrisonRegime"
                 }
               }
             }
           },
-          "404": {
-            "description": "The prison regime for this prison code was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -3416,12 +3478,12 @@
               }
             }
           },
-          "200": {
-            "description": "Prison regime found",
+          "404": {
+            "description": "The prison regime for this prison code was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PrisonRegime"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3456,8 +3518,21 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Requested resource not found",
+          "200": {
+            "description": "Successful call - zero or more cell locations found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Location"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": {
@@ -3486,21 +3561,8 @@
               }
             }
           },
-          "200": {
-            "description": "Successful call - zero or more cell locations found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Location"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3549,6 +3611,16 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -3561,16 +3633,6 @@
           },
           "403": {
             "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": {
@@ -3601,8 +3663,21 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Requested resource not found",
+          "200": {
+            "description": "Successful call - zero or more location groups found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LocationGroup"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": {
@@ -3631,21 +3706,8 @@
               }
             }
           },
-          "200": {
-            "description": "Successful call - zero or more location groups found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LocationGroup"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3739,16 +3801,6 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Search performed successfully",
             "content": {
@@ -3759,50 +3811,6 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/bulk-appointment-details/{bulkAppointmentId}": {
-      "get": {
-        "tags": [
-          "bulk-appointment-details-controller"
-        ],
-        "summary": "Gets the details of a set of appointments created as part of a single bulk operation for display purposes",
-        "description": "Returns the displayable details of a set of appointments created as part of a single bulk operation by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "getBulkAppointmentDetailsById",
-        "parameters": [
-          {
-            "name": "bulkAppointmentId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "Caseload-Id",
-            "in": "header",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -3813,18 +3821,8 @@
               }
             }
           },
-          "200": {
-            "description": "Bulk appointment found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkAppointmentDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The bulk appointment for this ID was not found.",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3864,6 +3862,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Attendance list found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AllAttendance"
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -3880,19 +3891,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Attendance list found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AllAttendance"
-                  }
                 }
               }
             }
@@ -3920,8 +3918,28 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Attendance found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attendance"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3939,26 +3957,6 @@
                 }
               }
             }
-          },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Attendance found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Attendance"
-                }
-              }
-            }
           }
         }
       }
@@ -3972,16 +3970,6 @@
         "description": "\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
         "operationId": "getAttendanceReasons",
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Attendance reasons found",
             "content": {
@@ -3991,6 +3979,16 @@
                   "items": {
                     "$ref": "#/components/schemas/AttendanceReason"
                   }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4008,14 +4006,14 @@
         }
       }
     },
-    "/appointments/{appointmentId}": {
+    "/appointments/{appointmentId}/details": {
       "get": {
         "tags": [
           "appointment-controller"
         ],
-        "summary": "Get an appointment by its id",
-        "description": "Returns an appointment and its details by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "getAppointmentById",
+        "summary": "Get the details of an appointment for display purposes by its id",
+        "description": "Returns the displayable details of an appointment by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentDetailsById",
         "parameters": [
           {
             "name": "appointmentId",
@@ -4039,6 +4037,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Appointment found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -4050,7 +4058,7 @@
             }
           },
           "404": {
-            "description": "The appointment for this ID was not found.",
+            "description": "The appointment for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4058,31 +4066,21 @@
                 }
               }
             }
-          },
-          "200": {
-            "description": "Appointment found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Appointment"
-                }
-              }
-            }
           }
         }
       }
     },
-    "/appointment-occurrence-details/{appointmentOccurrenceId}": {
+    "/appointment-set/{appointmentSetId}": {
       "get": {
         "tags": [
-          "appointment-occurrence-details-controller"
+          "appointment-set-controller"
         ],
-        "summary": "Gets the appointment occurrence details for display purposes identified by the appointment occurrence's id",
-        "description": "Returns the displayable details of an appointment occurrence by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "getAppointmentOccurrenceDetailsById",
+        "summary": "Get an appointment set by its id",
+        "description": "Returns an appointment set with its properties and references to NOMIS by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentSetById",
         "parameters": [
           {
-            "name": "appointmentOccurrenceId",
+            "name": "appointmentSetId",
             "in": "path",
             "required": true,
             "schema": {
@@ -4103,6 +4101,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Appointment set found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSet"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -4113,18 +4121,200 @@
               }
             }
           },
-          "200": {
-            "description": "Appointment Occurrence found",
+          "404": {
+            "description": "The appointment set for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AppointmentOccurrenceDetails"
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appointment-set/{appointmentSetId}/details": {
+      "get": {
+        "tags": [
+          "appointment-set-controller"
+        ],
+        "summary": "Get the details of an appointment set for display purposes by its id",
+        "description": "Returns the displayable details of an appointment set by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentSetDetailsById",
+        "parameters": [
+          {
+            "name": "appointmentSetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Appointment set found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSetDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "404": {
-            "description": "The appointment occurrence for this ID was not found.",
+            "description": "The appointment set for this id was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appointment-series/{appointmentSeriesId}": {
+      "get": {
+        "tags": [
+          "appointment-series-controller"
+        ],
+        "summary": "Get an appointment series by its id",
+        "description": "Returns an appointment series with its properties and references to NOMIS by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentSeriesById",
+        "parameters": [
+          {
+            "name": "appointmentSeriesId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Appointment series found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSeries"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The appointment series for this id was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appointment-series/{appointmentSeriesId}/details": {
+      "get": {
+        "tags": [
+          "appointment-series-controller"
+        ],
+        "summary": "Get the details of an appointment series for display purposes by its id",
+        "description": "Returns the displayable details of an appointment series by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentDetailsById_1",
+        "parameters": [
+          {
+            "name": "appointmentSeriesId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Appointment series found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSeriesDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The appointment series for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4212,6 +4402,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Appointment instance found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentInstance"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -4224,80 +4424,6 @@
           },
           "404": {
             "description": "The appointment instance for this ID was not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Appointment instance found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppointmentInstance"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/appointment-details/{appointmentId}": {
-      "get": {
-        "tags": [
-          "appointment-details-controller"
-        ],
-        "summary": "Gets the top level appointment details for display purposes identified by the appointment's id",
-        "description": "Returns the displayable details of an appointment by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "getAppointmentDetailsById",
-        "parameters": [
-          {
-            "name": "appointmentId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "Caseload-Id",
-            "in": "header",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Appointment found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppointmentDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The appointment for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4318,16 +4444,6 @@
         "description": "\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
         "operationId": "getAppointmentCategories",
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Appointment categories found",
             "content": {
@@ -4337,6 +4453,16 @@
                   "items": {
                     "$ref": "#/components/schemas/AppointmentCategorySummary"
                   }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4350,7 +4476,7 @@
           "allocation-controller"
         ],
         "summary": "Get an allocation by its id",
-        "description": "Returns a single allocation and its details by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "description": "Returns a single allocation and its details by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN\n* NOMIS_ACTIVITIES",
         "operationId": "getAllocationById",
         "parameters": [
           {
@@ -4375,22 +4501,22 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "allocation found",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Allocation"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4469,9 +4595,22 @@
           "activity-category-controller"
         ],
         "summary": "Get the list of top-level activity categories",
-        "description": "\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "description": "\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN\n* NOMIS_ACTIVITIES",
         "operationId": "getCategories",
         "responses": {
+          "200": {
+            "description": "Activity categories found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityCategory"
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
@@ -4491,19 +4630,6 @@
                 }
               }
             }
-          },
-          "200": {
-            "description": "Activity categories found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivityCategory"
-                  }
-                }
-              }
-            }
           }
         }
       }
@@ -4514,7 +4640,7 @@
           "activity-controller"
         ],
         "summary": "Get an activity by its id",
-        "description": "Returns a single activity and its details by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "description": "Returns a single activity and its details by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN\n* NOMIS_ACTIVITIES",
         "operationId": "getActivityById",
         "parameters": [
           {
@@ -4539,16 +4665,6 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Activity found",
             "content": {
@@ -4559,8 +4675,8 @@
               }
             }
           },
-          "404": {
-            "description": "The activity for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -4571,6 +4687,16 @@
           },
           "403": {
             "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The activity for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4602,12 +4728,12 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Activity ID not found",
+          "200": {
+            "description": "Activity schedules",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ActivityScheduleLite"
                 }
               }
             }
@@ -4622,18 +4748,18 @@
               }
             }
           },
-          "200": {
-            "description": "Activity schedules",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActivityScheduleLite"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "404": {
+            "description": "Activity ID not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4675,16 +4801,6 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Activity found",
             "content": {
@@ -4695,8 +4811,8 @@
               }
             }
           },
-          "404": {
-            "description": "The activity for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -4707,6 +4823,16 @@
           },
           "403": {
             "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The activity for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4738,16 +4864,6 @@
           }
         ],
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Activity found",
             "content": {
@@ -4758,8 +4874,8 @@
               }
             }
           },
-          "404": {
-            "description": "The activity for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -4770,6 +4886,16 @@
           },
           "403": {
             "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The activity for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4811,6 +4937,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "The activity was deleted."
+          },
           "400": {
             "description": "Bad request",
             "content": {
@@ -4840,9 +4969,6 @@
                 }
               }
             }
-          },
-          "200": {
-            "description": "The activity was deleted."
           }
         }
       }
@@ -5083,7 +5209,7 @@
         },
         "description": "Request object for updating an attendance record"
       },
-      "AppointmentOccurrenceCancelRequest": {
+      "AppointmentCancelRequest": {
         "required": [
           "applyTo",
           "cancellationReasonId"
@@ -5092,34 +5218,34 @@
         "properties": {
           "cancellationReasonId": {
             "type": "integer",
-            "description": "\n    Specifies the id of the reason for the cancellation. The cancellation reason, identified byt this ID, will determine \n    whether the cancellation is also treated as a soft delete\n    ",
+            "description": "\n    Specifies the id of the reason for the cancellation. The cancellation reason, identified by this id, will determine \n    whether the cancellation is also treated as a soft delete\n    ",
             "format": "int64",
             "example": 1234
           },
           "applyTo": {
             "type": "string",
-            "description": "\n    Specifies which appointment occurrence or occurrences this cancellation should apply to.\n    Defaults to THIS_OCCURRENCE meaning the cancellation will be applied to the appointment occurrence specified by the\n    supplied id only.\n    ",
-            "example": "THIS_OCCURRENCE",
+            "description": "\n    Specifies which appointment or appointments this cancellation should apply to.\n    Defaults to THIS_APPOINTMENT meaning the cancellation will be applied to the appointment specified by the\n    supplied id only.\n    ",
+            "example": "THIS_APPOINTMENT",
             "enum": [
-              "THIS_OCCURRENCE",
-              "THIS_AND_ALL_FUTURE_OCCURRENCES",
-              "ALL_FUTURE_OCCURRENCES"
+              "THIS_APPOINTMENT",
+              "THIS_AND_ALL_FUTURE_APPOINTMENTS",
+              "ALL_FUTURE_APPOINTMENTS"
             ]
           }
         },
-        "description": "The cancel request with the appointment occurrence details and how to apply the cancellation"
+        "description": "The cancel request with the cancellation details and how to apply the cancellation"
       },
       "Appointment": {
         "required": [
-          "appointmentType",
+          "attendees",
           "categoryCode",
-          "comment",
-          "created",
           "createdBy",
+          "createdTime",
           "id",
           "inCell",
-          "occurrences",
+          "isCancelled",
           "prisonCode",
+          "sequenceNumber",
           "startDate",
           "startTime"
         ],
@@ -5128,6 +5254,192 @@
           "id": {
             "type": "integer",
             "description": "The internally generated identifier for this appointment",
+            "format": "int64",
+            "example": 123456
+          },
+          "sequenceNumber": {
+            "type": "integer",
+            "description": "The sequence number of this appointment within the appointment series",
+            "format": "int32",
+            "example": 3
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
+            "example": "CHAP"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date this appointment is taking place on",
+            "format": "date"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of this appointment",
+            "format": "partial-time",
+            "example": "13:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of this appointment",
+            "format": "partial-time",
+            "example": "13:30"
+          },
+          "extraInformation": {
+            "type": "string",
+            "description": "\n    Extra information for the prisoner or prisoners attending this appointment.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment.\n    Usually a NOMIS username\n    ",
+            "example": "AAA01U"
+          },
+          "updatedTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment was last changed.\n    Will be null if this appointment has not been altered since it was created\n    ",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that edited this appointment.\n    Will be null if this appointment has not been altered since it was created\n    ",
+            "example": "AAA01U"
+          },
+          "cancelledTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment was cancelled.\n    Will be null if this appointment has not been cancelled\n    ",
+            "format": "date-time"
+          },
+          "cancellationReasonId": {
+            "type": "integer",
+            "description": "\n    The id of the reason why this appointment was cancelled.\n    Will be null if this appointment has not been cancelled\n    ",
+            "format": "int64",
+            "example": 12345
+          },
+          "cancelledBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that cancelled this appointment.\n    Will be null if this appointment has not been cancelled\n    ",
+            "example": "AAA01U"
+          },
+          "attendees": {
+            "type": "array",
+            "description": "\n    The prisoner or prisoners attending this appointment. Single appointments such as medical will have one\n    attendee. A group appointment e.g. gym or chaplaincy sessions will have more than one attendee.\n    Attendees are at the appointment level supporting alteration of attendees in any future appointment.\n    ",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentAttendee"
+            }
+          },
+          "isCancelled": {
+            "type": "boolean"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  All updates and cancellations happen at this appointment level with the parent appointment series being immutable.\n  "
+      },
+      "AppointmentAttendee": {
+        "required": [
+          "bookingId",
+          "id",
+          "prisonerNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for this prisoner attending a specific appointment in an appointment series or set.\n    N.B. this is used as the appointment instance id due to there being a one to one relationship between an appointment\n    attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
+            "example": "A1234BC"
+          },
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
+            "format": "int64",
+            "example": 456
+          },
+          "addedTime": {
+            "type": "string",
+            "description": "\n    The date and time this attendee was added appointment.\n    Will be null if this attendee was part of the appointment when the appointment was created\n    ",
+            "format": "date-time"
+          },
+          "addedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that added this attendee to the appointment.\n    Will be null if this attendee was part of the appointment when the appointment was created\n    ",
+            "example": "AAA01U"
+          },
+          "attended": {
+            "type": "boolean",
+            "description": "\n    Specifies whether the prisoner attended the specific appointment in an appointment series or set.\n    A null value means that the prisoner's attendance has not been recorded yet. \n    "
+          },
+          "attendanceRecordedTime": {
+            "type": "string",
+            "description": "\n    The date and time the attendance record the specific appointment in an appointment series or set was marked.\n    A null value means that the prisoner's attendance has not been recorded yet. \n    ",
+            "format": "date-time"
+          },
+          "attendanceRecordedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that marked the attendance record the specific appointment in\n    an appointment series or set.\n    A null value means that the prisoner's attendance has not been recorded yet. \n    ",
+            "example": "AAA01U"
+          },
+          "removedTime": {
+            "type": "string",
+            "description": "\n    The date and time this attendee was removed from the appointment.\n    Will be null if this attendee has not been removed from the appointment\n    ",
+            "format": "date-time"
+          },
+          "removedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that removed this attendee from the appointment.\n    Will be null if this attendee has not been removed from the appointment\n    ",
+            "example": "AAA01U"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Attendee\". A prisoner attending a specific appointment in an appointment series or set.\n  "
+      },
+      "AppointmentSeries": {
+        "required": [
+          "appointmentType",
+          "appointments",
+          "categoryCode",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "startDate",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment series",
             "format": "int64",
             "example": 12345
           },
@@ -5150,9 +5462,9 @@
             "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
             "example": "CHAP"
           },
-          "appointmentDescription": {
+          "customName": {
             "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
+            "description": "\n    Free text name further describing the appointment series. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
             "example": "Meeting with the governor"
           },
           "internalLocationId": {
@@ -5163,250 +5475,92 @@
           },
           "inCell": {
             "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "description": "\n    Flag to indicate if the location of the appointment series is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
             "example": false
           },
           "startDate": {
             "type": "string",
-            "description": "The date of the appointment or first appointment occurrence in the series",
+            "description": "The date of the first appointment in the series",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The starting time of the appointment or first appointment occurrence in the series",
+            "description": "The starting time of the appointment or appointments in the series",
             "format": "partial-time",
             "example": "09:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The end time of the appointment or first appointment occurrence in the series",
+            "description": "The end time of the appointment or appointments in the series",
             "format": "partial-time",
             "example": "10:30"
           },
-          "comment": {
+          "schedule": {
+            "$ref": "#/components/schemas/AppointmentSeriesSchedule"
+          },
+          "extraInformation": {
             "type": "string",
-            "description": "\n    Notes relating to the appointment.\n    The default value if no notes are specified at the occurrence or instance levels\n    ",
+            "description": "\n    Extra information for the prisoner or prisoners attending the appointment or appointments in the series.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
             "example": "This appointment will help adjusting to life outside of prison"
           },
-          "created": {
+          "createdTime": {
             "type": "string",
-            "description": "The date and time this appointment was created. Will not change",
+            "description": "The date and time this appointment series was created. Will not change",
             "format": "date-time"
           },
           "createdBy": {
             "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment.\n    Usually a NOMIS username\n    ",
+            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment series.\n    Usually a NOMIS username\n    ",
             "example": "AAA01U"
           },
-          "updated": {
+          "updatedTime": {
             "type": "string",
-            "description": "\n    The date and time this appointment was last changed.\n    Will be null if the appointment has not been altered since it was created\n    ",
+            "description": "\n    The date and time one or more appointments in this series was last changed.\n    Will be null if no appointments in the series have been altered since they were created\n    ",
             "format": "date-time"
           },
           "updatedBy": {
             "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that edited the appointment.\n    Will be null if the appointment has not been altered since it was created\n    ",
+            "description": "\n    The username of the user authenticated via HMPPS auth that last edited one or more appointments in this series.\n    Will be null if no appointments in the series have been altered since they were created\n    ",
             "example": "AAA01U"
           },
-          "schedule": {
-            "$ref": "#/components/schemas/AppointmentSchedule"
-          },
-          "occurrences": {
+          "appointments": {
             "type": "array",
-            "description": "\n    The individual occurrence or occurrences of this appointment. Non recurring appointments will have a single\n    appointment occurrence containing the same property values as the parent appointment. The same start date, time\n    and end time. Recurring appointments will have a series of occurrences. The first in the series will also\n    contain the same property values as the parent appointment and subsequent occurrences will have start dates\n    following on from the original start date incremented as specified by the appointment's schedule. Each occurrence\n    can be edited independently of the parent. All properties of an occurrence override those of the parent appointment\n    with a null coalesce back to the parent for nullable properties. The full series of occurrences specified by the\n    schedule will be created in advance.\n    ",
+            "description": "\n    The individual appointment or appointments in this series. Non recurring appointment series will have a single\n    appointment containing the same property values as the parent appointment series. The same start date, time\n    and end time. Recurring appointment series will have one or more appointments. The first in the series will also\n    contain the same property values as the parent appointment series and subsequent appointments will have start dates\n    following on from the original start date incremented as specified by the series' schedule. Each appointment\n    can be edited independently of the parent. All properties of an appointment are separate to those of the parent\n    appointment series. The full series of appointments specified by the schedule will have been created in advance.\n    ",
             "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrence"
+              "$ref": "#/components/schemas/Appointment"
             }
           }
         },
-        "description": "\n  The top level appointment containing the initial values for all appointment properties.\n  Joins together one or more appointment occurrences and optionally a schedule if the appointment is recurring.\n  The child appointment occurrences will by default have the same property values.\n  The occurrence property values can be changed independently to support rescheduling, cancelling and altered\n  attendee lists at an individual occurrence level.\n  Editing a property at the appointment level will cascade the edit to all *future* child occurrences\n  "
+        "description": "\n  Described on the UI as an \"Appointment series\" and only shown for repeat appointments.\n  The top level of the standard appointment hierarchy containing the initial property values common to all appointments\n  in the series.\n  Contains the collection of all the child appointments in the series plus the schedule definition if the appointment series repeats.\n  The properties at this level cannot be changed via the API however the child appointment property values can be changed\n  independently to support rescheduling, cancelling and altered attendee lists per appointment.\n  N.B. there is no collection of attending prisoners at this top level as all attendees are per appointment. This is to\n  support attendee modification for each scheduled appointment and to prevent altering the past by editing attendees\n  in an appointment series where some appointments have past.\n  "
       },
-      "AppointmentOccurrence": {
+      "AppointmentSeriesSchedule": {
         "required": [
-          "allocations",
-          "id",
-          "inCell",
-          "isCancelled",
-          "sequenceNumber",
-          "startDate",
-          "startTime"
+          "frequency",
+          "numberOfAppointments"
         ],
         "type": "object",
         "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence",
-            "format": "int64",
-            "example": 123456
+          "frequency": {
+            "type": "string",
+            "description": "\n    The frequency of the appointments in the repeating appointment series. When they will repeat and how often\n    ",
+            "example": "WEEKLY",
+            "enum": [
+              "WEEKDAY",
+              "DAILY",
+              "WEEKLY",
+              "FORTNIGHTLY",
+              "MONTHLY"
+            ]
           },
-          "sequenceNumber": {
+          "numberOfAppointments": {
+            "minimum": 1,
             "type": "integer",
-            "description": "The sequence number of this appointment occurrence within the recurring appointment series",
+            "description": "\n    The original total number of appointments in the appointment series i.e. the number that were created initially\n    without excluding any that were subsequently cancelled or deleted\n    ",
             "format": "int32",
-            "example": 3
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date this appointment occurrence is taking place on",
-            "format": "date"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of this appointment occurrence",
-            "format": "partial-time",
-            "example": "13:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of this appointment occurrence",
-            "format": "partial-time",
-            "example": "13:30"
-          },
-          "comment": {
-            "type": "string",
-            "description": "\n    Notes relating to this appointment occurrence.\n    The comment value from the parent appointment will be used if this is null\n    ",
-            "example": "This appointment occurrence has been rescheduled due to staff availability"
-          },
-          "cancelled": {
-            "type": "string",
-            "description": "\n    The time at which this appointment occurrence was cancelled (if applicable).\n    ",
-            "format": "date-time"
-          },
-          "cancellationReasonId": {
-            "type": "integer",
-            "description": "\n    The ID of the reason why this appointment occurrence was cancelled (if applicable).\n    ",
-            "format": "int64",
-            "example": 12345
-          },
-          "cancelledBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that cancelled this appointment instance (if applicable).\n    Usually a NOMIS username. Will be null if the appointment occurrence has not been altered independently from the\n    parent appointment since it was created\n    ",
-            "example": "AAA01U"
-          },
-          "updated": {
-            "type": "string",
-            "description": "\n    The date and time this appointment occurrence was last changed.\n    Will be null if the appointment occurrence has not been altered independently from the parent appointment\n    since it was created\n    ",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that edited this appointment instance.\n    Usually a NOMIS username. Will be null if the appointment occurrence has not been altered independently from the\n    parent appointment since it was created\n    ",
-            "example": "AAA01U"
-          },
-          "allocations": {
-            "type": "array",
-            "description": "\n    The prisoner or prisoners attending this appointment occurrence. Single appointments such as medical will have one\n    allocation record. A group appointment e.g. gym or chaplaincy sessions will have more than one allocation record.\n    Allocations are at the occurrence level supporting alteration of attendees in any future occurrence.\n    When viewing or editing a recurring appointment, the allocations from the next appointment occurrence in the series\n    will be used.\n    ",
-            "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrenceAllocation"
-            }
-          },
-          "isCancelled": {
-            "type": "boolean"
+            "example": 6
           }
         },
-        "description": "\n  Represents a specific appointment occurrence. Non recurring appointments will have a single appointment occurrence\n  containing the same property values as the parent appointment. The same start date, time and end time. Recurring\n  appointments will have a series of occurrences. The first in the series will also contain the same property values\n  as the parent appointment and subsequent occurrences will have start dates following on from the original start date\n  incremented as specified by the appointment's schedule. Each occurrence can be edited independently of the parent.\n  All properties of an occurrence override those of the parent appointment with a null coalesce back to the parent for\n  nullable properties. The full series of occurrences specified by the schedule will be created in advance.\n  "
-      },
-      "AppointmentOccurrenceAllocation": {
-        "required": [
-          "bookingId",
-          "id",
-          "prisonerNumber"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence allocation",
-            "format": "int64",
-            "example": 123456
-          },
-          "prisonerNumber": {
-            "type": "string",
-            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
-            "example": "A1234BC"
-          },
-          "bookingId": {
-            "type": "integer",
-            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
-            "format": "int64",
-            "example": 456
-          }
-        },
-        "description": "\n  The allocation of a prisoner to an appointment occurrence. Appointments of type INDIVIDUAL will have one prisoner\n  allocated to each appointment occurrence. Appointments of type GROUP can have more than one prisoner allocated to each\n  appointment occurrence\n  "
-      },
-      "AppointmentSchedule": {
-        "required": [
-          "endDate",
-          "fridayFlag",
-          "id",
-          "mondayFlag",
-          "saturdayFlag",
-          "sundayFlag",
-          "thursdayFlag",
-          "tuesdayFlag",
-          "wednesdayFlag"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this appointment schedule",
-            "format": "int64",
-            "example": 12345
-          },
-          "endDate": {
-            "type": "string",
-            "description": "\n    The date the series of appointment occurrences should end. The UI will provide options to specify an end date or\n    a number of occurrences. The later case should be used to calculate the end date internally\n    ",
-            "format": "date"
-          },
-          "mondayFlag": {
-            "type": "boolean",
-            "description": "Indicates the appointment reoccurs every Monday",
-            "example": false
-          },
-          "tuesdayFlag": {
-            "type": "boolean",
-            "description": "Indicates the appointment reoccurs every Tuesday",
-            "example": true
-          },
-          "wednesdayFlag": {
-            "type": "boolean",
-            "description": "Indicates the appointment reoccurs every Wednesday",
-            "example": false
-          },
-          "thursdayFlag": {
-            "type": "boolean",
-            "description": "Indicates the appointment reoccurs every Thursday",
-            "example": false
-          },
-          "fridayFlag": {
-            "type": "boolean",
-            "description": "Indicates the appointment reoccurs every Friday",
-            "example": false
-          },
-          "saturdayFlag": {
-            "type": "boolean",
-            "description": "Indicates the appointment reoccurs every Saturday",
-            "example": false
-          },
-          "sundayFlag": {
-            "type": "boolean",
-            "description": "Indicates the appointment reoccurs every Sunday",
-            "example": false
-          }
-        },
-        "description": "\n  Describes the recurrence of an appointment. The days of the week an occurrence of the appointment will be scheduled\n  and the end date of the series.\n  "
+        "description": "\n  Describes the schedule of the appointment i.e. how the appointments in the series will repeat. The frequency of\n  those appointments and how many appointments there will be in total in the series.\n  "
       },
       "PrisonerAllocationRequest": {
         "required": [
@@ -5524,6 +5678,7 @@
         "required": [
           "cancelled",
           "inCell",
+          "offWing",
           "onWing",
           "outsidePrison",
           "priority",
@@ -5553,28 +5708,23 @@
             "format": "int64",
             "example": 9999
           },
+          "appointmentSeriesId": {
+            "type": "integer",
+            "description": "For appointments from SAA the ID for the appointment series, or null when from NOMIS",
+            "format": "int64",
+            "example": 9999
+          },
           "appointmentId": {
             "type": "integer",
             "description": "For appointments from SAA the ID for the appointment, or null when from NOMIS",
             "format": "int64",
             "example": 9999
           },
-          "appointmentOccurrenceId": {
+          "appointmentAttendeeId": {
             "type": "integer",
-            "description": "For appointments from SAA the ID for the appointment occurrence, or null when from NOMIS",
+            "description": "For appointments from SAA the ID for the appointment attendee, or null when from NOMIS",
             "format": "int64",
             "example": 9999
-          },
-          "appointmentInstanceId": {
-            "type": "integer",
-            "description": "For appointments from SAA the ID for the appointment instance, or null when from NOMIS",
-            "format": "int64",
-            "example": 9999
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "For appointments from SAA the optional appointment description",
-            "example": "Meeting with the governor"
           },
           "oicHearingId": {
             "type": "integer",
@@ -5640,6 +5790,11 @@
             "description": "Flag to indicate if the location of the activity is on wing",
             "example": false
           },
+          "offWing": {
+            "type": "boolean",
+            "description": "Flag to indicate if the location of the activity is off wing and not in a listed location",
+            "example": false
+          },
           "outsidePrison": {
             "type": "boolean",
             "description": "Set to true if this event takes place outside the prison",
@@ -5688,6 +5843,7 @@
       },
       "Allocation": {
         "required": [
+          "activityId",
           "activitySummary",
           "bookingId",
           "id",
@@ -5720,6 +5876,10 @@
           },
           "activitySummary": {
             "type": "string"
+          },
+          "activityId": {
+            "type": "integer",
+            "format": "int64"
           },
           "scheduleId": {
             "type": "integer",
@@ -6350,6 +6510,140 @@
         },
         "description": "The migration request with the appointment details"
       },
+      "AppointmentInstance": {
+        "required": [
+          "appointmentAttendeeId",
+          "appointmentDate",
+          "appointmentId",
+          "appointmentSeriesId",
+          "appointmentType",
+          "bookingId",
+          "categoryCode",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "prisonerNumber",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for this appointment instance. N.B. this is the appointment attendee id due to\n    there being a one to one relationship between an appointment attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "appointmentSeriesId": {
+            "type": "integer",
+            "description": "The internally generated identifier for the appointment series",
+            "format": "int64",
+            "example": 1234
+          },
+          "appointmentId": {
+            "type": "integer",
+            "description": "The internally generated identifier for the appointment",
+            "format": "int64",
+            "example": 12345
+          },
+          "appointmentAttendeeId": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for the appointment attendee. N.B. this is used as the appointment instance id\n    due to there being a one to one relationship between an appointment attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "appointmentType": {
+            "type": "string",
+            "description": "The appointment type (INDIVIDUAL or GROUP)",
+            "example": "INDIVIDUAL",
+            "enum": [
+              "INDIVIDUAL",
+              "GROUP"
+            ]
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
+            "example": "A1234BC"
+          },
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
+            "format": "int64",
+            "example": 456
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
+            "example": "CHAP"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment instance. Used as part of the appointment name with the\n    format \"Appointment description (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment instance is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "example": false
+          },
+          "appointmentDate": {
+            "type": "string",
+            "description": "The date of the appointment instance",
+            "format": "date"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of the appointment instance",
+            "format": "partial-time",
+            "example": "09:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of the appointment instance",
+            "format": "partial-time",
+            "example": "10:30"
+          },
+          "extraInformation": {
+            "type": "string",
+            "description": "\n    Extra information for the prisoner attending this appointment instance.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment instance was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment instance.\n    Usually a NOMIS username\n    ",
+            "example": "AAA01U"
+          },
+          "updatedTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment instance was last changed.\n    Will be null if this appointment instance has not been altered since it was created\n    ",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that edited this appointment instance.\n    Will be null if this appointment instance has not been altered since it was created\n    ",
+            "example": "AAA01U"
+          }
+        },
+        "description": "\n  Represents an appointment instance for a specific prisoner to attend at the specified location, date and time.\n  The fully denormalised representation of the appointment series, appointments and attendees equivalent to a row in\n  the NOMIS OFFENDER_IND_SCHEDULES table.\n  Appointment instances do not exist as database records and are the product of the join between appointment attendees,\n  appointments and appointment series. \n  The appointment attendee id is used for the appointment instance id as there is a one to one relationship between an\n  appointment attendee and appointment instances.\n  Appointment instances are used primarily for the one way sync to NOMIS.\n  "
+      },
       "EventAcknowledgeRequest": {
         "required": [
           "eventReviewIds"
@@ -6372,168 +6666,6 @@
           }
         },
         "description": "The prisoner allocation request details"
-      },
-      "BulkAppointmentsRequest": {
-        "required": [
-          "appointments",
-          "categoryCode",
-          "inCell",
-          "internalLocationId",
-          "prisonCode",
-          "startDate"
-        ],
-        "type": "object",
-        "properties": {
-          "prisonCode": {
-            "maxLength": 3,
-            "minLength": 0,
-            "type": "string",
-            "description": "The NOMIS prison code where these appointments takes place",
-            "example": "PVI"
-          },
-          "categoryCode": {
-            "type": "string",
-            "description": "The NOMIS reference code for these appointments. Must exist and be active",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "maxLength": 40,
-            "minLength": 0,
-            "type": "string",
-            "description": "\n    Free text description for these appointments.  This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property and be active. \n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointments is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date of the appointments",
-            "format": "date"
-          },
-          "appointments": {
-            "type": "array",
-            "description": "\n    The list of appointments to create\n    ",
-            "items": {
-              "$ref": "#/components/schemas/IndividualAppointment"
-            }
-          }
-        },
-        "description": "The create request containing the new appointments"
-      },
-      "IndividualAppointment": {
-        "required": [
-          "comment",
-          "endTime",
-          "prisonerNumber",
-          "startTime"
-        ],
-        "type": "object",
-        "properties": {
-          "prisonerNumber": {
-            "type": "string",
-            "description": "The prisoner to allocate to the created appointment",
-            "example": "A1234BC"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of the appointment",
-            "format": "partial-time",
-            "example": "09:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of the appointment",
-            "format": "partial-time",
-            "example": "10:30"
-          },
-          "comment": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "description": "\n    Notes relating to the appointment.\n    ",
-            "example": "This appointment will help adjusting to life outside of prison"
-          }
-        },
-        "description": "\n    The list of appointments to create\n    "
-      },
-      "BulkAppointment": {
-        "required": [
-          "appointments",
-          "categoryCode",
-          "created",
-          "createdBy",
-          "id",
-          "inCell",
-          "prisonCode",
-          "startDate"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this set of appointments",
-            "format": "int64",
-            "example": 12345
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
-            "example": "SKI"
-          },
-          "categoryCode": {
-            "type": "string",
-            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date of the appointment or first appointment occurrence in the series",
-            "format": "date"
-          },
-          "appointments": {
-            "type": "array",
-            "description": "The set of appointments created in bulk",
-            "items": {
-              "$ref": "#/components/schemas/Appointment"
-            }
-          },
-          "created": {
-            "type": "string",
-            "description": "The date and time this set of appointment was created in bulk. Will not change",
-            "format": "date-time"
-          },
-          "createdBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that created this set of appointments in bulk.\n    Usually a NOMIS username\n    ",
-            "example": "AAA01U"
-          }
-        },
-        "description": "Describes a set of appointments created as part of a single bulk operation"
       },
       "AuditRecordSearchFilters": {
         "type": "object",
@@ -6559,7 +6691,8 @@
             "example": "ACTIVITY",
             "enum": [
               "PRISONER",
-              "ACTIVITY"
+              "ACTIVITY",
+              "APPOINTMENT"
             ]
           },
           "auditEventType": {
@@ -6569,7 +6702,13 @@
             "enum": [
               "ACTIVITY_CREATED",
               "ACTIVITY_UPDATED",
+              "APPOINTMENT_CANCELLED",
+              "APPOINTMENT_CANCELLED_ON_TRANSFER",
+              "APPOINTMENT_SERIES_CREATED",
+              "APPOINTMENT_DELETED",
+              "APPOINTMENT_EDITED",
               "BONUS_PAYMENT_MADE_FOR_ACTIVITY_ATTENDANCE",
+              "APPOINTMENT_SET_CREATED",
               "INCENTIVE_LEVEL_WARNING_GIVEN_FOR_ACTIVITY_ATTENDANCE",
               "PRISONER_ACCEPTED_FROM_WAITING_LIST",
               "PRISONER_ADDED_TO_WAITING_LIST",
@@ -6634,7 +6773,8 @@
             "example": "ACTIVITY",
             "enum": [
               "PRISONER",
-              "ACTIVITY"
+              "ACTIVITY",
+              "APPOINTMENT"
             ]
           },
           "auditEventType": {
@@ -6644,7 +6784,13 @@
             "enum": [
               "ACTIVITY_CREATED",
               "ACTIVITY_UPDATED",
+              "APPOINTMENT_CANCELLED",
+              "APPOINTMENT_CANCELLED_ON_TRANSFER",
+              "APPOINTMENT_SERIES_CREATED",
+              "APPOINTMENT_DELETED",
+              "APPOINTMENT_EDITED",
               "BONUS_PAYMENT_MADE_FOR_ACTIVITY_ATTENDANCE",
+              "APPOINTMENT_SET_CREATED",
               "INCENTIVE_LEVEL_WARNING_GIVEN_FOR_ACTIVITY_ATTENDANCE",
               "PRISONER_ACCEPTED_FROM_WAITING_LIST",
               "PRISONER_ADDED_TO_WAITING_LIST",
@@ -6720,131 +6866,7 @@
         },
         "description": "The result of an audit record search"
       },
-      "AppointmentCreateRequest": {
-        "required": [
-          "appointmentType",
-          "categoryCode",
-          "comment",
-          "endTime",
-          "inCell",
-          "prisonCode",
-          "prisonerNumbers",
-          "startDate",
-          "startTime"
-        ],
-        "type": "object",
-        "properties": {
-          "appointmentType": {
-            "type": "string",
-            "description": "The appointment type (INDIVIDUAL or GROUP)",
-            "example": "INDIVIDUAL",
-            "enum": [
-              "INDIVIDUAL",
-              "GROUP"
-            ]
-          },
-          "prisonCode": {
-            "maxLength": 3,
-            "minLength": 0,
-            "type": "string",
-            "description": "The NOMIS prison code where this appointment takes place",
-            "example": "PVI"
-          },
-          "prisonerNumbers": {
-            "type": "array",
-            "description": "The prisoner or prisoners to allocate to the created appointment or series of appointment occurrences",
-            "example": [
-              "A1234BC"
-            ],
-            "items": {
-              "type": "string",
-              "description": "The prisoner or prisoners to allocate to the created appointment or series of appointment occurrences",
-              "example": "[\"A1234BC\"]"
-            }
-          },
-          "categoryCode": {
-            "type": "string",
-            "description": "The NOMIS reference code for this appointment. Must exist and be active",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "maxLength": 40,
-            "minLength": 0,
-            "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property and be active. \n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date of the appointment or first appointment occurrence in the series",
-            "format": "date"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of the appointment or first appointment occurrence in the series",
-            "format": "partial-time",
-            "example": "09:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of the appointment or first appointment occurrence in the series",
-            "format": "partial-time",
-            "example": "10:30"
-          },
-          "repeat": {
-            "$ref": "#/components/schemas/AppointmentRepeat"
-          },
-          "comment": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "description": "\n    Notes relating to the appointment.\n    The default value if no notes are specified at the occurrence or instance levels\n    ",
-            "example": "This appointment will help adjusting to life outside of prison"
-          }
-        },
-        "description": "The create request with the new appointment or series of appointment occurrences details"
-      },
-      "AppointmentRepeat": {
-        "required": [
-          "count",
-          "period"
-        ],
-        "type": "object",
-        "properties": {
-          "period": {
-            "type": "string",
-            "description": "\n    The period or frequency of the occurrences in the repeating appointment series. When they will repeat and how often\n    ",
-            "example": "WEEKLY",
-            "enum": [
-              "WEEKDAY",
-              "DAILY",
-              "WEEKLY",
-              "FORTNIGHTLY",
-              "MONTHLY"
-            ]
-          },
-          "count": {
-            "minimum": 1,
-            "type": "integer",
-            "description": "\n    The total number of occurrences in the appointment series\n    ",
-            "format": "int32",
-            "example": 6
-          }
-        },
-        "description": "\n  Describes how an appointment will repeat. The period or frequency of those occurrences and how many occurrences there\n  will be in total in the series.\n  "
-      },
-      "AppointmentOccurrenceSearchRequest": {
+      "AppointmentSearchRequest": {
         "required": [
           "startDate"
         ],
@@ -6852,7 +6874,7 @@
         "properties": {
           "appointmentType": {
             "type": "string",
-            "description": "\n    The appointment type (INDIVIDUAL or GROUP) match with the parent appointments. Will restrict the search results to\n    appointment occurrences that have a parent appointment with the matching type when this search parameter is supplied.\n    ",
+            "description": "\n    The appointment type (INDIVIDUAL or GROUP) to match with the appointment series. Will restrict the search results to\n    appointments that are part of a series with the matching type when this search parameter is supplied.\n    ",
             "example": "INDIVIDUAL",
             "enum": [
               "INDIVIDUAL",
@@ -6861,17 +6883,17 @@
           },
           "startDate": {
             "type": "string",
-            "description": "\n    The start date to match with the appointment occurrences. Will restrict the search results to appointment\n    occurrences that have the matching start date when this search parameter is supplied but no end date is supplied.\n    When an end date is also supplied, the search uses a date range and will restrict the search results to appointment\n    occurrences that have a start date within the date range.\n    ",
+            "description": "\n    The start date to match with the appointments. Will restrict the search results to appointments\n    that have the matching start date when this search parameter is supplied but no end date is supplied.\n    When an end date is also supplied, the search uses a date range and will restrict the search results to\n    appointments that have a start date within the date range.\n    ",
             "format": "date"
           },
           "endDate": {
             "type": "string",
-            "description": "\n    The end date of the date range to match with the appointment occurrences. Start date must be supplied if an end date\n    is specified. Will restrict the search results to appointment occurrences that have a start date within the date range.\n    ",
+            "description": "\n    The end date of the date range to match with the appointments. Start date must be supplied if an end date\n    is specified. Will restrict the search results to appointments that have a start date within the date range.\n    ",
             "format": "date"
           },
           "timeSlot": {
             "type": "string",
-            "description": "\n    The time slot to match with the appointment occurrences. Will restrict the search results to appointment occurrences\n    that have a start time between the times defined by the prison for that time slot when this search parameter is\n    supplied.\n    ",
+            "description": "\n    The time slot to match with the appointments. Will restrict the search results to appointments that have a start\n    time between the times defined by the prison for that time slot when this search parameter is supplied.\n    ",
             "example": "PM",
             "enum": [
               "AM",
@@ -6881,39 +6903,67 @@
           },
           "categoryCode": {
             "type": "string",
-            "description": "\n    The NOMIS reference code to match with the parent appointments. Will restrict the search results to appointment\n    occurrences that have a parent appointment with the matching category code when this search parameter is supplied.\n    ",
+            "description": "\n    The NOMIS reference code to match with the appointments. Will restrict the search results to appointments\n    that have the matching category code when this search parameter is supplied.\n    ",
             "example": "GYMW"
           },
           "internalLocationId": {
             "type": "integer",
-            "description": "\n    The NOMIS internal location id to match with the appointment occurrences. Will restrict the search results to\n    appointment occurrences that have the matching internal location id when this search parameter is supplied.\n    ",
+            "description": "\n    The NOMIS internal location id to match with the appointments. Will restrict the search results to\n    appointments that have the matching internal location id when this search parameter is supplied.\n    ",
             "format": "int64",
             "example": 123
           },
           "inCell": {
             "type": "boolean",
-            "description": "\n    The in cell flag value to match with the appointment occurrences. Will restrict the search results to appointment\n    occurrences that have the matching in cell value when this search parameter is supplied.\n    ",
+            "description": "\n    The in cell flag value to match with the appointments. Will restrict the search results to appointments\n    that have the matching in cell value when this search parameter is supplied.\n    ",
             "example": false
           },
           "prisonerNumbers": {
             "type": "array",
-            "description": "\n    The allocated prisoner or prisoners to match with the appointment occurrences. Will restrict the search results to\n    appointment occurrences that have the at least one of the supplied prisoner numbers allocated to them when this\n    search parameter is supplied.\n    ",
+            "description": "\n    The allocated prisoner or prisoners to match with the appointments. Will restrict the search results to\n    appointments that have the at least one of the supplied prisoner numbers attending when this search parameter\n    is supplied.\n    ",
             "example": [
               "A1234BC"
             ],
             "items": {
               "type": "string",
-              "description": "\n    The allocated prisoner or prisoners to match with the appointment occurrences. Will restrict the search results to\n    appointment occurrences that have the at least one of the supplied prisoner numbers allocated to them when this\n    search parameter is supplied.\n    ",
+              "description": "\n    The allocated prisoner or prisoners to match with the appointments. Will restrict the search results to\n    appointments that have the at least one of the supplied prisoner numbers attending when this search parameter\n    is supplied.\n    ",
               "example": "[\"A1234BC\"]"
             }
           },
           "createdBy": {
             "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth to match with the parent appointments. Will restrict the\n    search results to appointment occurrences that have a parent appointment created by this username when this search\n    parameter is supplied.\n    ",
+            "description": "\n    The username of the user authenticated via HMPPS auth to match with the appointments. Will restrict the\n    search results to appointments that were created by this username when this search parameter is supplied.\n    ",
             "example": "AAA01U"
           }
         },
-        "description": "The search parameters to use to filter appointment occurrences"
+        "description": "The search parameters to use to filter appointments"
+      },
+      "AppointmentAttendeeSearchResult": {
+        "required": [
+          "appointmentAttendeeId",
+          "bookingId",
+          "prisonerNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "appointmentAttendeeId": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for this prisoner attending a specific appointment in an appointment series or set.\n    N.B. this is used as the appointment instance id due to there being a one to one relationship between an appointment\n    attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
+            "example": "A1234BC"
+          },
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
+            "format": "int64",
+            "example": 456
+          }
+        },
+        "description": "\n  Summary search result details of a specific appointment attendee found via search. Contains properties needed to\n  make additional API calls and to populate a table of search results.\n  "
       },
       "AppointmentCategorySummary": {
         "required": [
@@ -6962,13 +7012,13 @@
         },
         "description": "\n  Summarises an appointment location for display purposes. Contains only properties needed to make additional API calls\n  and to display. NOMIS is the current system of record for appointment locations and they are managed there.\n  "
       },
-      "AppointmentOccurrenceSearchResult": {
+      "AppointmentSearchResult": {
         "required": [
-          "allocations",
           "appointmentId",
           "appointmentName",
-          "appointmentOccurrenceId",
+          "appointmentSeriesId",
           "appointmentType",
+          "attendees",
           "category",
           "inCell",
           "isCancelled",
@@ -6983,21 +7033,21 @@
         ],
         "type": "object",
         "properties": {
-          "appointmentId": {
+          "appointmentSeriesId": {
             "type": "integer",
-            "description": "The internally generated identifier for the parent appointment",
+            "description": "The internally generated identifier for the appointment series",
             "format": "int64",
             "example": 12345
           },
-          "appointmentOccurrenceId": {
+          "appointmentId": {
             "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence",
+            "description": "The internally generated identifier for this appointment",
             "format": "int64",
             "example": 123456
           },
           "appointmentType": {
             "type": "string",
-            "description": "The parent appointment's type (INDIVIDUAL or GROUP)",
+            "description": "The type of the appointment series (INDIVIDUAL or GROUP)",
             "example": "INDIVIDUAL",
             "enum": [
               "INDIVIDUAL",
@@ -7006,26 +7056,26 @@
           },
           "prisonCode": {
             "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    Note, this property does not exist on the appointment occurrences and is therefore consistent across all occurrences\n    ",
+            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    ",
             "example": "SKI"
           },
           "appointmentName": {
             "type": "string",
-            "description": "\n    The appointment name\n    "
+            "description": "\n    The appointment's name combining the optional custom name with the category description. If custom name has been\n    specified, the name format will be \"Custom name (Category description)\" \n    "
           },
-          "allocations": {
+          "attendees": {
             "type": "array",
-            "description": "\n    The prisoner or prisoners attending this appointment occurrence. Appointments of type INDIVIDUAL will have one\n    prisoner allocated to each appointment occurrence. Appointments of type GROUP can have more than one prisoner\n    allocated to each appointment occurrence\n    ",
+            "description": "\n    The prisoner or prisoners attending this appointment. Appointments of type INDIVIDUAL will have one\n    prisoner attending to each appointment. Appointments of type GROUP can have more than one prisoner\n    attending each appointment\n    ",
             "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrenceAllocation"
+              "$ref": "#/components/schemas/AppointmentAttendeeSearchResult"
             }
           },
           "category": {
             "$ref": "#/components/schemas/AppointmentCategorySummary"
           },
-          "appointmentDescription": {
+          "customName": {
             "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
+            "description": "\n    Free text name further describing the appointment. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
             "example": "Meeting with the governor"
           },
           "internalLocation": {
@@ -7038,55 +7088,309 @@
           },
           "startDate": {
             "type": "string",
-            "description": "The date this appointment occurrence is taking place on",
+            "description": "The date this appointment is taking place on",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The starting time of this appointment occurrence",
+            "description": "The starting time of this appointment",
             "format": "partial-time",
             "example": "13:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The end time of this appointment occurrence",
+            "description": "The end time of this appointment",
             "format": "partial-time",
             "example": "13:30"
           },
           "isRepeat": {
             "type": "boolean",
-            "description": "Indicates whether the parent appointment was specified to repeat",
+            "description": "Indicates whether the appointment series was specified to repeat via its schedule",
             "example": false
           },
           "sequenceNumber": {
             "type": "integer",
-            "description": "The sequence number of this appointment occurrence within the recurring appointment series",
+            "description": "The sequence number of this appointment within the appointment series",
             "format": "int32",
             "example": 3
           },
           "maxSequenceNumber": {
             "type": "integer",
-            "description": "The sequence number of the final appointment occurrence within the recurring appointment series",
+            "description": "The sequence number of the final appointment within the appointment series",
             "format": "int32",
             "example": 6
           },
           "isEdited": {
             "type": "boolean",
-            "description": "Indicates whether this appointment occurrence has been changed from its original state",
+            "description": "Indicates whether this appointment has been changed from its original state",
             "example": false
           },
           "isCancelled": {
             "type": "boolean",
-            "description": "Indicates whether this appointment occurrence has been cancelled",
+            "description": "Indicates whether this appointment has been cancelled",
             "example": false
           },
           "isExpired": {
             "type": "boolean",
-            "description": "Indicates whether this appointment occurrence has expired",
+            "description": "Indicates whether this appointment has expired",
             "example": false
           }
         },
-        "description": "\n  Summary search result details of a specific appointment occurrence found via search. Will contain copies of the parent\n  appointment's properties unless they have been changed on this appointment occurrence. Contains properties needed to\n  make additional API calls and to populate a table of search results.\n  "
+        "description": "\n  Summary search result details of a specific appointment found via search. Contains properties needed to\n  make additional API calls and to populate a table of search results.\n  "
+      },
+      "AppointmentSetAppointment": {
+        "required": [
+          "endTime",
+          "prisonerNumber",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The prisoner attending the appointment",
+            "example": "A1234BC"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of the appointment",
+            "format": "partial-time",
+            "example": "09:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of the appointment",
+            "format": "partial-time",
+            "example": "10:30"
+          },
+          "extraInformation": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "description": "\n    Extra information for the prisoner or prisoners attending the appointment. Shown only on the appointments details\n    page and on printed movement slips. Wing staff will be notified there is extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          }
+        },
+        "description": "\n    The list of appointments to create\n    "
+      },
+      "AppointmentSetCreateRequest": {
+        "required": [
+          "appointments",
+          "categoryCode",
+          "inCell",
+          "prisonCode",
+          "startDate"
+        ],
+        "type": "object",
+        "properties": {
+          "prisonCode": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "description": "The NOMIS prison code where these appointments takes place",
+            "example": "PVI"
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS reference code for these appointments. Must exist and be active",
+            "example": "CHAP"
+          },
+          "customName": {
+            "maxLength": 40,
+            "minLength": 0,
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment series. Will be used to create the appointment name using the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property and be active. \n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointments is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date of the appointments",
+            "format": "date"
+          },
+          "appointments": {
+            "type": "array",
+            "description": "\n    The list of appointments to create\n    ",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentSetAppointment"
+            }
+          }
+        },
+        "description": "The create request with the new appointment set details"
+      },
+      "AppointmentSet": {
+        "required": [
+          "appointments",
+          "categoryCode",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "startDate"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment set",
+            "format": "int64",
+            "example": 12345
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
+            "example": "CHAP"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment set. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment set is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date of the first appointment in each appointment series in the set",
+            "format": "date"
+          },
+          "appointments": {
+            "type": "array",
+            "description": "The appointments in the set",
+            "items": {
+              "$ref": "#/components/schemas/Appointment"
+            }
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment set was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that created this appointment set.\n    Usually a NOMIS username\n    ",
+            "example": "AAA01U"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the initial property values common to all appointment series and appointments in the set.\n  The properties at this level cannot be changed via the API.\n  "
+      },
+      "AppointmentSeriesCreateRequest": {
+        "required": [
+          "appointmentType",
+          "categoryCode",
+          "endTime",
+          "inCell",
+          "prisonCode",
+          "prisonerNumbers",
+          "startDate",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "appointmentType": {
+            "type": "string",
+            "description": "The appointment type (INDIVIDUAL or GROUP)",
+            "example": "INDIVIDUAL",
+            "enum": [
+              "INDIVIDUAL",
+              "GROUP"
+            ]
+          },
+          "prisonCode": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "description": "The NOMIS prison code where this appointment series takes place",
+            "example": "PVI"
+          },
+          "prisonerNumbers": {
+            "type": "array",
+            "description": "The prisoner or prisoners attending the appointment or appointments in the series",
+            "example": [
+              "A1234BC"
+            ],
+            "items": {
+              "type": "string",
+              "description": "The prisoner or prisoners attending the appointment or appointments in the series",
+              "example": "[\"A1234BC\"]"
+            }
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS reference code for this appointment. Must exist and be active",
+            "example": "CHAP"
+          },
+          "customName": {
+            "maxLength": 40,
+            "minLength": 0,
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment series. Will be used to create the appointment name using the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property and be active. \n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment series is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date of the first appointment in the series",
+            "format": "date"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of the appointment or appointments in the series",
+            "format": "partial-time",
+            "example": "09:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of the appointment or appointments in the series",
+            "format": "partial-time",
+            "example": "10:30"
+          },
+          "schedule": {
+            "$ref": "#/components/schemas/AppointmentSeriesSchedule"
+          },
+          "extraInformation": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "description": "\n    Extra information for the prisoner or prisoners attending the appointment or appointments in the series.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          }
+        },
+        "description": "The create request with the new appointment series details"
       },
       "WaitingListApplicationRequest": {
         "required": [
@@ -7155,6 +7459,7 @@
           "minimumEducationLevel",
           "minimumIncentiveLevel",
           "minimumIncentiveNomisCode",
+          "offWing",
           "onWing",
           "outsideWork",
           "pay",
@@ -7189,6 +7494,11 @@
           "onWing": {
             "type": "boolean",
             "description": "Flag to indicate if the location of the activity is on wing",
+            "example": false
+          },
+          "offWing": {
+            "type": "boolean",
+            "description": "Flag to indicate if the location of the activity is off wing and not in a listed location",
             "example": false
           },
           "pieceWork": {
@@ -7498,6 +7808,7 @@
           "minimumEducationLevel",
           "minimumIncentiveLevel",
           "minimumIncentiveNomisCode",
+          "offWing",
           "onWing",
           "outsideWork",
           "pay",
@@ -7535,6 +7846,11 @@
           "onWing": {
             "type": "boolean",
             "description": "Flag to indicate if the location of the activity is on wing",
+            "example": false
+          },
+          "offWing": {
+            "type": "boolean",
+            "description": "Flag to indicate if the location of the activity is off wing and not in a listed location",
             "example": false
           },
           "pieceWork": {
@@ -7716,6 +8032,7 @@
           "minimumEducationLevel",
           "minimumIncentiveLevel",
           "minimumIncentiveNomisCode",
+          "offWing",
           "onWing",
           "outsideWork",
           "payPerSession",
@@ -7750,6 +8067,11 @@
           "onWing": {
             "type": "boolean",
             "description": "Flag to indicate if the location of the activity is on wing",
+            "example": false
+          },
+          "offWing": {
+            "type": "boolean",
+            "description": "Flag to indicate if the location of the activity is off wing and not in a listed location",
             "example": false
           },
           "pieceWork": {
@@ -8560,6 +8882,7 @@
       },
       "WaitingListApplication": {
         "required": [
+          "activityId",
           "bookingId",
           "createdBy",
           "creationTime",
@@ -8578,6 +8901,12 @@
             "description": "The internally-generated ID for this waiting list",
             "format": "int64",
             "example": 111111
+          },
+          "activityId": {
+            "type": "integer",
+            "description": "The internally-generated ID for the associated activity",
+            "format": "int64",
+            "example": 1000
           },
           "scheduleId": {
             "type": "integer",
@@ -8663,86 +8992,92 @@
         },
         "description": "Describes a single waiting list application for a prisoner who is waiting to be allocated to an activity."
       },
-      "AppointmentOccurrenceUpdateRequest": {
+      "AppointmentUpdateRequest": {
         "required": [
-          "applyTo"
+          "applyTo",
+          "isPropertyUpdate"
         ],
         "type": "object",
         "properties": {
           "categoryCode": {
             "type": "string",
-            "description": "\n    The updated NOMIS reference code for the parent appointment. Must exist and be active.\n    NOTE: updating the category will apply to all appointment occurrences as the category is associated with the\n    parent appointment only. The value for applyTo will be ignored.\n    ",
+            "description": "\n    The updated NOMIS reference code. Must exist and be active.\n    ",
             "example": "GYMW"
           },
           "internalLocationId": {
             "type": "integer",
-            "description": "\n    The updated NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property on the\n    parent appointment and be active. \n    ",
+            "description": "\n    The updated NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property on the\n    appointment and be active. \n    ",
             "format": "int64",
             "example": 123
           },
           "inCell": {
             "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment occurrence is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
+            "description": "\n    Flag to indicate if the location of the appointment or appointments is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
             "example": false
           },
           "startDate": {
             "type": "string",
-            "description": "\n    The updated date of the appointment occurrence. NOTE: this property specifies the day or date of all or all future\n    occurrences when used in conjunction with the applyTo property\n    ",
+            "description": "\n    The updated date of the appointment. NOTE: this property specifies the start date to use along with the existing\n    schedule frequency to move all appointments that will take place after the appointment when used in conjunction\n    with the applyTo property\n    ",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The updated starting time of the appointment occurrence",
+            "description": "The updated starting time",
             "format": "partial-time",
             "example": "09:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The updated end time of the appointment occurrence",
+            "description": "The updated end time",
             "format": "partial-time",
             "example": "10:30"
           },
-          "comment": {
+          "extraInformation": {
+            "maxLength": 4000,
+            "minLength": 0,
             "type": "string",
-            "description": "Updated notes relating to the appointment occurrence",
-            "example": "This appointment occurrence has been rescheduled due to staff availability"
+            "description": "\n    Updated extra information for the prisoner or prisoners attending the appointment or appointments.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
           },
           "removePrisonerNumbers": {
             "type": "array",
-            "description": "The prisoner or prisoners to deallocate from the appointment occurrence",
+            "description": "The prisoner or prisoners to remove from the appointment or appointments",
             "example": [
               "A1234BC"
             ],
             "items": {
               "type": "string",
-              "description": "The prisoner or prisoners to deallocate from the appointment occurrence",
+              "description": "The prisoner or prisoners to remove from the appointment or appointments",
               "example": "[\"A1234BC\"]"
             }
           },
           "addPrisonerNumbers": {
             "type": "array",
-            "description": "The replacement prisoner or prisoners to allocate to the appointment occurrence",
+            "description": "The new prisoner or prisoners that will be attending the appointment or appointments",
             "example": [
               "A1234BC"
             ],
             "items": {
               "type": "string",
-              "description": "The replacement prisoner or prisoners to allocate to the appointment occurrence",
+              "description": "The new prisoner or prisoners that will be attending the appointment or appointments",
               "example": "[\"A1234BC\"]"
             }
           },
           "applyTo": {
             "type": "string",
-            "description": "\n    Specifies which appointment occurrence or occurrences this update should apply to.\n    Defaults to THIS_OCCURRENCE meaning the update will be applied to the appointment occurrence specified by the\n    supplied id only.\n    ",
-            "example": "THIS_OCCURRENCE",
+            "description": "\n    Specifies which appointment or appointments this update should apply to.\n    Defaults to THIS_APPOINTMENT meaning the update will be applied to the appointment specified by the\n    supplied id only.\n    ",
+            "example": "THIS_APPOINTMENT",
             "enum": [
-              "THIS_OCCURRENCE",
-              "THIS_AND_ALL_FUTURE_OCCURRENCES",
-              "ALL_FUTURE_OCCURRENCES"
+              "THIS_APPOINTMENT",
+              "THIS_AND_ALL_FUTURE_APPOINTMENTS",
+              "ALL_FUTURE_APPOINTMENTS"
             ]
+          },
+          "isPropertyUpdate": {
+            "type": "boolean"
           }
         },
-        "description": "The update request with the new appointment occurrence details and how to apply the update"
+        "description": "The update request with the new appointment details and how to apply the update"
       },
       "AllocationUpdateRequest": {
         "type": "object",
@@ -8869,6 +9204,11 @@
           "onWing": {
             "type": "boolean",
             "description": "Flag to indicate if the location of the activity is on wing",
+            "example": false
+          },
+          "offWing": {
+            "type": "boolean",
+            "description": "Flag to indicate if the location of the activity is off wing and not in a listed location",
             "example": false
           },
           "attendanceRequired": {
@@ -9590,13 +9930,13 @@
       "PageActivityCandidate": {
         "type": "object",
         "properties": {
-          "totalElements": {
-            "type": "integer",
-            "format": "int64"
-          },
           "totalPages": {
             "type": "integer",
             "format": "int32"
+          },
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
           },
           "size": {
             "type": "integer",
@@ -9615,15 +9955,15 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "first": {
-            "type": "boolean"
-          },
           "numberOfElements": {
             "type": "integer",
             "format": "int32"
           },
           "pageable": {
             "$ref": "#/components/schemas/PageableObject"
+          },
+          "first": {
+            "type": "boolean"
           },
           "last": {
             "type": "boolean"
@@ -9643,11 +9983,11 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "pageSize": {
+          "pageNumber": {
             "type": "integer",
             "format": "int32"
           },
-          "pageNumber": {
+          "pageSize": {
             "type": "integer",
             "format": "int32"
           },
@@ -9665,10 +10005,10 @@
           "empty": {
             "type": "boolean"
           },
-          "sorted": {
+          "unsorted": {
             "type": "boolean"
           },
-          "unsorted": {
+          "sorted": {
             "type": "boolean"
           }
         }
@@ -10222,325 +10562,6 @@
         },
         "description": "The result of an event review search"
       },
-      "AppointmentOccurrenceDetails": {
-        "required": [
-          "appointmentId",
-          "appointmentName",
-          "appointmentType",
-          "category",
-          "comment",
-          "created",
-          "createdBy",
-          "id",
-          "inCell",
-          "isCancelled",
-          "isEdited",
-          "isExpired",
-          "prisonCode",
-          "prisoners",
-          "sequenceNumber",
-          "startDate",
-          "startTime"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence",
-            "format": "int64",
-            "example": 123456
-          },
-          "appointmentId": {
-            "type": "integer",
-            "description": "The internally generated identifier for the parent appointment",
-            "format": "int64",
-            "example": 12345
-          },
-          "bulkAppointment": {
-            "$ref": "#/components/schemas/BulkAppointmentSummary"
-          },
-          "appointmentType": {
-            "type": "string",
-            "description": "The appointment type (INDIVIDUAL or GROUP)",
-            "example": "INDIVIDUAL",
-            "enum": [
-              "INDIVIDUAL",
-              "GROUP"
-            ]
-          },
-          "sequenceNumber": {
-            "type": "integer",
-            "description": "The sequence number of this appointment occurrence within the recurring appointment series",
-            "format": "int32",
-            "example": 3
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    Note, this property does not exist on the appointment occurrences and is therefore consistent across all occurrences\n    ",
-            "example": "SKI"
-          },
-          "appointmentName": {
-            "type": "string",
-            "description": "\n    The appointment name\n    "
-          },
-          "prisoners": {
-            "type": "array",
-            "description": "\n    Summary of the prisoner or prisoners allocated to this appointment occurrence. Prisoners are allocated at the\n    occurrence level to allow for per occurrence allocation changes.\n    ",
-            "items": {
-              "$ref": "#/components/schemas/PrisonerSummary"
-            }
-          },
-          "category": {
-            "$ref": "#/components/schemas/AppointmentCategorySummary"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocation": {
-            "$ref": "#/components/schemas/AppointmentLocationSummary"
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date this appointment occurrence is taking place on",
-            "format": "date"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of this appointment occurrence",
-            "format": "partial-time",
-            "example": "13:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of this appointment occurrence",
-            "format": "partial-time",
-            "example": "13:30"
-          },
-          "comment": {
-            "type": "string",
-            "description": "\n    Notes relating to this appointment occurrence. Can be different to the parent appointment if this occurrence has\n    been edited.\n    ",
-            "example": "This appointment occurrence has been rescheduled due to staff availability"
-          },
-          "repeat": {
-            "$ref": "#/components/schemas/AppointmentRepeat"
-          },
-          "isEdited": {
-            "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has been independently changed from the original state it was in when\n    it was created as part of a recurring series\n    ",
-            "example": false
-          },
-          "isCancelled": {
-            "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has been cancelled\n    ",
-            "example": false
-          },
-          "isExpired": {
-            "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has expired\n    ",
-            "example": false
-          },
-          "created": {
-            "type": "string",
-            "description": "The date and time the parent appointment was created. Will not change",
-            "format": "date-time"
-          },
-          "createdBy": {
-            "$ref": "#/components/schemas/UserSummary"
-          },
-          "updated": {
-            "type": "string",
-            "description": "\n    The date and time this appointment occurrence was last edited.\n    Will be null if the appointment occurrence has not been independently changed from the original state it was in when\n    it was created as part of a recurring series\n    ",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "$ref": "#/components/schemas/UserSummary"
-          },
-          "cancelled": {
-            "type": "string",
-            "description": "\n    The date and time this appointment occurrence was cancelled\n    ",
-            "format": "date-time"
-          },
-          "cancelledBy": {
-            "$ref": "#/components/schemas/UserSummary"
-          }
-        },
-        "description": "\n  Details of a specific appointment occurrence. Will contain copies of the parent appointment's properties unless they\n  have been changed on this appointment occurrence. Contains only properties needed to make additional API calls\n  and to display.\n  "
-      },
-      "BulkAppointmentDetails": {
-        "required": [
-          "appointmentName",
-          "category",
-          "created",
-          "createdBy",
-          "id",
-          "inCell",
-          "occurrences",
-          "prisonCode",
-          "startDate"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this set of appointments",
-            "format": "int64",
-            "example": 12345
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    Note, this property does not exist on the appointment occurrences and is therefore consistent across all occurrences\n    ",
-            "example": "SKI"
-          },
-          "appointmentName": {
-            "type": "string",
-            "description": "\n    The appointment name\n    "
-          },
-          "category": {
-            "$ref": "#/components/schemas/AppointmentCategorySummary"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description used to create the set of appointments in bulk. This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocation": {
-            "$ref": "#/components/schemas/AppointmentLocationSummary"
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location used to create the set of appointments in bulk was in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date used to create the set of appointments in bulk",
-            "format": "date"
-          },
-          "occurrences": {
-            "type": "array",
-            "description": "The details of the set of appointment occurrences created in bulk",
-            "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrenceDetails"
-            }
-          },
-          "created": {
-            "type": "string",
-            "description": "The date and time this set of appointments was created in bulk. Will not change",
-            "format": "date-time"
-          },
-          "createdBy": {
-            "$ref": "#/components/schemas/UserSummary"
-          }
-        },
-        "description": "Describes a set of appointments created as part of a single bulk operation"
-      },
-      "BulkAppointmentSummary": {
-        "required": [
-          "appointmentCount",
-          "id"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this set of appointments",
-            "format": "int64",
-            "example": 12345
-          },
-          "appointmentCount": {
-            "type": "integer",
-            "description": "\n    The number of appointments in the set created in bulk\n    ",
-            "format": "int32",
-            "example": 3
-          }
-        },
-        "description": "Summarises a set of appointments created as part of a single bulk operation"
-      },
-      "PrisonerSummary": {
-        "required": [
-          "bookingId",
-          "cellLocation",
-          "firstName",
-          "lastName",
-          "prisonCode",
-          "prisonerNumber"
-        ],
-        "type": "object",
-        "properties": {
-          "prisonerNumber": {
-            "type": "string",
-            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
-            "example": "A1234BC"
-          },
-          "bookingId": {
-            "type": "integer",
-            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
-            "format": "int64",
-            "example": 456
-          },
-          "firstName": {
-            "type": "string",
-            "description": "The prisoner's first name",
-            "example": "Albert"
-          },
-          "lastName": {
-            "type": "string",
-            "description": "The prisoner's first name",
-            "example": "Abbot"
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    ",
-            "example": "SKI"
-          },
-          "cellLocation": {
-            "type": "string",
-            "description": "\n    The prisoner's residential cell location when inside the prison.\n    ",
-            "example": "A-1-002"
-          }
-        },
-        "description": "\n    Summary of the prisoner or prisoners allocated to the first future occurrence (or most recent past occurrence if all\n    occurrences are in the past) of this appointment. Prisoners are allocated at the occurrence level to allow for per\n    occurrence allocation changes. The occurrence summary does not contain any information on the allocated prisoners\n    as the expected usage is to show a summary of the occurrences then a link to display the full occurrence details.\n    "
-      },
-      "UserSummary": {
-        "required": [
-          "firstName",
-          "id",
-          "lastName",
-          "username"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The NOMIS STAFF_MEMBERS.STAFF_ID value for mapping to NOMIS.",
-            "format": "int64",
-            "example": 36
-          },
-          "username": {
-            "type": "string",
-            "description": "The NOMIS STAFF_USER_ACCOUNTS.USERNAME value for mapping to NOMIS",
-            "example": "AAA01U"
-          },
-          "firstName": {
-            "type": "string",
-            "description": "The user's first name",
-            "example": "Alice"
-          },
-          "lastName": {
-            "type": "string",
-            "description": "The user's last name",
-            "example": "Akbar"
-          }
-        },
-        "description": "\n    The summary of the last user to edit this appointment occurrence. Will be null if the appointment occurrence has not\n    been independently changed from the original state it was in when it was created as part of a recurring series\n    "
-      },
       "AllAttendance": {
         "required": [
           "activityId",
@@ -10627,48 +10648,405 @@
         },
         "description": "\n  Represents the key data required to report on attendance \n  "
       },
-      "AppointmentInstance": {
+      "AppointmentAttendeeSummary": {
         "required": [
-          "appointmentDate",
-          "appointmentId",
-          "appointmentOccurrenceAllocationId",
-          "appointmentOccurrenceId",
+          "id",
+          "prisoner"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for this prisoner attending a specific appointment in an appointment series or set.\n    N.B. this is used as the appointment instance id due to there being a one to one relationship between an appointment\n    attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "prisoner": {
+            "$ref": "#/components/schemas/PrisonerSummary"
+          },
+          "attended": {
+            "type": "boolean",
+            "description": "\n    Specifies whether the prisoner attended the specific appointment in an appointment series or set.\n    A null value means that the prisoner's attendance has not been recorded yet. \n    "
+          }
+        },
+        "description": "\n  Described on the UI as an \"Attendee\". A prisoner attending a specific appointment in an appointment series or set.\n  Contains the limited summary information needed to display the prisoner information and whether they attended or not.\n  "
+      },
+      "AppointmentDetails": {
+        "required": [
+          "appointmentName",
           "appointmentType",
-          "bookingId",
-          "categoryCode",
-          "created",
+          "attendees",
+          "category",
           "createdBy",
+          "createdTime",
           "id",
           "inCell",
+          "isCancelled",
+          "isEdited",
+          "isExpired",
           "prisonCode",
-          "prisonerNumber",
+          "sequenceNumber",
+          "startDate",
           "startTime"
         ],
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "description": "The internally generated identifier for this appointment instance",
+            "description": "The internally generated identifier for this appointment",
             "format": "int64",
             "example": 123456
           },
-          "appointmentId": {
-            "type": "integer",
-            "description": "The internally generated identifier for the parent appointment",
-            "format": "int64",
-            "example": 1234
+          "appointmentSeries": {
+            "$ref": "#/components/schemas/AppointmentSeriesSummary"
           },
-          "appointmentOccurrenceId": {
+          "appointmentSet": {
+            "$ref": "#/components/schemas/AppointmentSetSummary"
+          },
+          "appointmentType": {
+            "type": "string",
+            "description": "The appointment type (INDIVIDUAL or GROUP)",
+            "example": "INDIVIDUAL",
+            "enum": [
+              "INDIVIDUAL",
+              "GROUP"
+            ]
+          },
+          "sequenceNumber": {
             "type": "integer",
-            "description": "The internally generated identifier for the parent appointment occurrence",
+            "description": "The sequence number of this appointment within the appointment series",
+            "format": "int32",
+            "example": 3
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "appointmentName": {
+            "type": "string",
+            "description": "\n    The appointment's name combining the optional custom name with the category description. If custom name has been\n    specified, the name format will be \"Custom name (Category description)\" \n    "
+          },
+          "attendees": {
+            "type": "array",
+            "description": "\n    Summary of the prisoner or prisoners attending this appointment and their attendance record if any.\n    Attendees are at the appointment level to allow for per appointment attendee changes.\n    ",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentAttendeeSummary"
+            }
+          },
+          "category": {
+            "$ref": "#/components/schemas/AppointmentCategorySummary"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocation": {
+            "$ref": "#/components/schemas/AppointmentLocationSummary"
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date this appointment is taking place on",
+            "format": "date"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of this appointment",
+            "format": "partial-time",
+            "example": "13:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of this appointment",
+            "format": "partial-time",
+            "example": "13:30"
+          },
+          "isExpired": {
+            "type": "boolean",
+            "description": "\n    Indicates that this appointment has expired i.e. it's start date and time is in the past\n    ",
+            "example": false
+          },
+          "extraInformation": {
+            "type": "string",
+            "description": "\n    Extra information for the prisoner or prisoners attending this appointment.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          },
+          "isEdited": {
+            "type": "boolean",
+            "description": "\n    Indicates that this appointment has been independently changed from the original state it was in when\n    it was created as part of an appointment series\n    ",
+            "example": false
+          },
+          "updatedTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment was last changed.\n    Will be null if this appointment has not been altered since it was created\n    ",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          },
+          "isCancelled": {
+            "type": "boolean",
+            "description": "\n    Indicates that this appointment has been cancelled\n    ",
+            "example": false
+          },
+          "cancelledTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment was cancelled.\n    Will be null if this appointment has not been cancelled\n    ",
+            "format": "date-time"
+          },
+          "cancelledBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  Contains the full details of all the appointment properties and the summary collection of prisoners attending this appointment.\n  An appointment is part of either a series of an appointments on a schedule or a set of appointments on the same day.\n  The summary information of which appointment collection they are part of is included in these details.\n  All updates and cancellations happen at this appointment level with the parent appointment series being immutable.\n  "
+      },
+      "AppointmentSeriesSummary": {
+        "required": [
+          "appointmentCount",
+          "id",
+          "scheduledAppointmentCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment series",
             "format": "int64",
             "example": 12345
           },
-          "appointmentOccurrenceAllocationId": {
+          "schedule": {
+            "$ref": "#/components/schemas/AppointmentSeriesSchedule"
+          },
+          "appointmentCount": {
             "type": "integer",
-            "description": "The internally generated identifier for the parent appointment occurrence allocation",
+            "description": "\n    The total count of appointments in the series that have not been deleted. Counts both appointments in the past and\n    those scheduled.\n    ",
+            "format": "int32"
+          },
+          "scheduledAppointmentCount": {
+            "type": "integer",
+            "description": "\n    The count of the remaining scheduled appointments in the series that have not been cancelled or deleted.\n    ",
+            "format": "int32"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment series\" and only shown for repeat appointments.\n  The top level of the standard appointment hierarchy containing summary information of a limited set of the initial\n  property values common to all appointments in the series as well as the count of appointments in the series.\n  The properties at this level cannot be changed via the API however the child appointment property values can be changed\n  independently to support rescheduling, cancelling and altered attendee lists per appointment.\n  N.B. there is no collection of attending prisoners at this top level as all attendees are per appointment. This is to\n  support attendee modification for each scheduled appointment and to prevent altering the past by editing attendees\n  in an appointment series where some appointments have past.\n  "
+      },
+      "AppointmentSetSummary": {
+        "required": [
+          "appointmentCount",
+          "id",
+          "scheduledAppointmentCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment set",
             "format": "int64",
-            "example": 123456
+            "example": 12345
+          },
+          "appointmentCount": {
+            "type": "integer",
+            "description": "\n    The number of appointments in the set that have not been deleted. Counts both appointments in the past and\n    those scheduled.\n    ",
+            "format": "int32",
+            "example": 3
+          },
+          "scheduledAppointmentCount": {
+            "type": "integer",
+            "description": "\n    The count of the remaining scheduled appointments in the set that have not been cancelled or deleted.\n    ",
+            "format": "int32"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the limited summary information needed to display the fact that an appointment was created as part of a set.\n  "
+      },
+      "PrisonerSummary": {
+        "required": [
+          "bookingId",
+          "cellLocation",
+          "firstName",
+          "lastName",
+          "prisonCode",
+          "prisonerNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
+            "example": "A1234BC"
+          },
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
+            "format": "int64",
+            "example": 456
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The prisoner's first name",
+            "example": "Albert"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The prisoner's first name",
+            "example": "Abbot"
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    ",
+            "example": "SKI"
+          },
+          "cellLocation": {
+            "type": "string",
+            "description": "\n    The prisoner's residential cell location when inside the prison.\n    ",
+            "example": "A-1-002"
+          }
+        },
+        "description": "Summary of the prisoner attending the appointment"
+      },
+      "UserSummary": {
+        "required": [
+          "firstName",
+          "id",
+          "lastName",
+          "username"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The NOMIS STAFF_MEMBERS.STAFF_ID value for mapping to NOMIS.",
+            "format": "int64",
+            "example": 36
+          },
+          "username": {
+            "type": "string",
+            "description": "The NOMIS STAFF_USER_ACCOUNTS.USERNAME value for mapping to NOMIS",
+            "example": "AAA01U"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The user's first name",
+            "example": "Alice"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The user's last name",
+            "example": "Akbar"
+          }
+        },
+        "description": "\n    The summary of the user that last edited one or more appointments in this series.\n    Will be null if no appointments in the series have been altered since they were created\n    "
+      },
+      "AppointmentSetDetails": {
+        "required": [
+          "appointmentName",
+          "appointments",
+          "category",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "startDate"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment set",
+            "format": "int64",
+            "example": 12345
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "appointmentName": {
+            "type": "string",
+            "description": "\n    The appointment set's name combining the optional custom name with the category description. If custom name has been\n    specified, the name format will be \"Custom name (Category description)\" \n    "
+          },
+          "category": {
+            "$ref": "#/components/schemas/AppointmentCategorySummary"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment set. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocation": {
+            "$ref": "#/components/schemas/AppointmentLocationSummary"
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment series in the set is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date of the first appointment in each appointment series in the set",
+            "format": "date"
+          },
+          "appointments": {
+            "type": "array",
+            "description": "The details of all the appointments in the the set",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentDetails"
+            }
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment set was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          },
+          "updatedTime": {
+            "type": "string",
+            "description": "\n    The date and time one or more appointments in this set was last changed.\n    Will be null if no appointments in the set have been altered since they were created\n    ",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the full details of the initial property values common to all appointments in the set for display purposes.\n  The properties at this level cannot be changed via the API.\n  "
+      },
+      "AppointmentSeriesDetails": {
+        "required": [
+          "appointmentName",
+          "appointmentType",
+          "appointments",
+          "category",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "startDate",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment series",
+            "format": "int64",
+            "example": 12345
           },
           "appointmentType": {
             "type": "string",
@@ -10684,138 +11062,16 @@
             "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
             "example": "SKI"
           },
-          "prisonerNumber": {
-            "type": "string",
-            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
-            "example": "A1234BC"
-          },
-          "bookingId": {
-            "type": "integer",
-            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
-            "format": "int64",
-            "example": 456
-          },
-          "categoryCode": {
-            "type": "string",
-            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
-            "example": false
-          },
-          "appointmentDate": {
-            "type": "string",
-            "description": "The date of the appointment instance",
-            "format": "date"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of the appointment instance",
-            "format": "partial-time",
-            "example": "09:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of the appointment instance",
-            "format": "partial-time",
-            "example": "10:30"
-          },
-          "comment": {
-            "type": "string",
-            "description": "\n    Notes relating to the appointment instance.\n    Could support adding a note specific to an individual prisoner's attendance of a specific group appointment\n    occurrence. Something that is supported within existing systems\n    ",
-            "example": "This appointment will help prisoner A1234BC adjust to life outside of prison"
-          },
-          "created": {
-            "type": "string",
-            "description": "The date and time this appointment instance was created. Will not change",
-            "format": "date-time"
-          },
-          "createdBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment instance.\n    Usually a NOMIS username\n    ",
-            "example": "AAA01U"
-          },
-          "updated": {
-            "type": "string",
-            "description": "\n    The date and time this appointment instance was last changed.\n    Will be null if the appointment instance has not been altered since it was created\n    ",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that edited the appointment instance.\n    Will be null if the appointment instance has not been altered since it was created\n    ",
-            "example": "AAA01U"
-          }
-        },
-        "description": "\n  Represents an appointment instance for a specific prisoner to attend at the specified location, date and time.\n  The fully denormalised representation of the appointment occurrences and allocations.\n  "
-      },
-      "AppointmentDetails": {
-        "required": [
-          "appointmentName",
-          "appointmentType",
-          "category",
-          "comment",
-          "created",
-          "createdBy",
-          "id",
-          "inCell",
-          "occurrences",
-          "prisonCode",
-          "prisoners",
-          "startDate",
-          "startTime"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this appointment",
-            "format": "int64",
-            "example": 12345
-          },
-          "appointmentType": {
-            "type": "string",
-            "description": "The appointment type (INDIVIDUAL or GROUP)",
-            "example": "INDIVIDUAL",
-            "enum": [
-              "INDIVIDUAL",
-              "GROUP"
-            ]
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    Note, this property does not exist on the appointment occurrences and is therefore consistent across all occurrences\n    ",
-            "example": "SKI"
-          },
           "appointmentName": {
             "type": "string",
-            "description": "\n    The appointment name\n    "
-          },
-          "prisoners": {
-            "type": "array",
-            "description": "\n    Summary of the prisoner or prisoners allocated to the first future occurrence (or most recent past occurrence if all\n    occurrences are in the past) of this appointment. Prisoners are allocated at the occurrence level to allow for per\n    occurrence allocation changes. The occurrence summary does not contain any information on the allocated prisoners\n    as the expected usage is to show a summary of the occurrences then a link to display the full occurrence details.\n    ",
-            "items": {
-              "$ref": "#/components/schemas/PrisonerSummary"
-            }
+            "description": "\n    The appointment series' name combining the optional custom name with the category description. If custom name has been\n    specified, the name format will be \"Custom name (Category description)\" \n    "
           },
           "category": {
             "$ref": "#/components/schemas/AppointmentCategorySummary"
           },
-          "appointmentDescription": {
+          "customName": {
             "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
+            "description": "\n    Free text name further describing the appointment series. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
             "example": "Meeting with the governor"
           },
           "internalLocation": {
@@ -10823,65 +11079,63 @@
           },
           "inCell": {
             "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
+            "description": "\n    Flag to indicate if the location of the appointment series is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
             "example": false
           },
           "startDate": {
             "type": "string",
-            "description": "The date of the appointment or first appointment occurrence in the series",
+            "description": "The date of the first appointment in the series",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The starting time of the appointment or first appointment occurrence in the series",
+            "description": "The starting time of the appointment or appointments in the series",
             "format": "partial-time",
             "example": "09:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The end time of the appointment or first appointment occurrence in the series",
+            "description": "The end time of the appointment or appointments in the series",
             "format": "partial-time",
             "example": "10:30"
           },
-          "repeat": {
-            "$ref": "#/components/schemas/AppointmentRepeat"
+          "schedule": {
+            "$ref": "#/components/schemas/AppointmentSeriesSchedule"
           },
-          "comment": {
+          "extraInformation": {
             "type": "string",
-            "description": "\n    Notes relating to the appointment\n    ",
+            "description": "\n    Extra information for the prisoner or prisoners attending the appointment or appointments in the series.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
             "example": "This appointment will help adjusting to life outside of prison"
           },
-          "created": {
+          "createdTime": {
             "type": "string",
-            "description": "The date and time this appointment was created. Will not change",
+            "description": "The date and time this appointment series was created. Will not change",
             "format": "date-time"
           },
           "createdBy": {
             "$ref": "#/components/schemas/UserSummary"
           },
-          "updated": {
+          "updatedTime": {
             "type": "string",
-            "description": "\n    The date and time this appointment was last changed.\n    Will be null if the appointment has not been edited since it was created\n    ",
+            "description": "\n    The date and time one or more appointments in this series was last changed.\n    Will be null if no appointments in the series have been altered since they were created\n    ",
             "format": "date-time"
           },
           "updatedBy": {
             "$ref": "#/components/schemas/UserSummary"
           },
-          "occurrences": {
+          "appointments": {
             "type": "array",
-            "description": "\n    Summary of the individual occurrence or occurrences of this appointment. Non recurring appointments will have a single\n    appointment occurrence containing the same property values as the parent appointment. The same start date, time\n    and end time. Recurring appointments will have a series of occurrences. The first in the series will also\n    contain the same property values as the parent appointment and subsequent occurrences will have start dates\n    following on from the original start date incremented as specified by the appointment's schedule. Each occurrence\n    can be edited independently of the parent. All properties of an occurrence override those of the parent appointment\n    with a null coalesce back to the parent for nullable properties. The full series of occurrences specified by the\n    schedule will be created in advance.\n    ",
+            "description": "\n    Summary of the individual appointment or appointments in this series both expired and scheduled.\n    Non recurring appointment series will have a single appointment containing the same property values as the parent\n    appointment series. The same start date, time and end time. Recurring appointment series will have one or more\n    appointments. The first in the series will also contain the same property values as the parent appointment series\n    and subsequent appointments will have start dates following on from the original start date incremented as specified\n    by the series' schedule. Each appointment can be edited independently of the parent. All properties of an\n    appointment are separate to those of the parent appointment series.\n    The full series of appointments specified by the schedule will have been created in advance.\n    ",
             "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrenceSummary"
+              "$ref": "#/components/schemas/AppointmentSummary"
             }
           }
         },
-        "description": "\n  The top level appointment details for display purposes. Contains only properties needed to make additional API calls\n  and to display.\n  "
+        "description": "\n  Described on the UI as an \"Appointment series\" and only shown for repeat appointments.\n  The top level of the standard appointment hierarchy containing full details of the initial property values common to\n  all appointments in the series for display purposes.\n  Contains the summary collection of all the child appointments in the series plus the schedule definition if the\n  appointment series repeats.\n  The properties at this level cannot be changed via the API however the child appointment property values can be changed\n  independently to support rescheduling, cancelling and altered attendee lists per appointment.\n  N.B. there is no collection of attending prisoners at this top level as all attendees are per appointment. This is to\n  support attendee modification for each scheduled appointment and to prevent altering the past by editing attendees\n  in an appointment series where some appointments have past.\n  "
       },
-      "AppointmentOccurrenceSummary": {
+      "AppointmentSummary": {
         "required": [
-          "comment",
           "id",
-          "inCell",
           "isCancelled",
           "isEdited",
           "sequenceNumber",
@@ -10892,66 +11146,45 @@
         "properties": {
           "id": {
             "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence",
+            "description": "The internally generated identifier for this appointment",
             "format": "int64",
             "example": 123456
           },
           "sequenceNumber": {
             "type": "integer",
-            "description": "The sequence number of this appointment occurrence within the recurring appointment series",
+            "description": "The sequence number of this appointment within the appointment series",
             "format": "int32",
             "example": 3
           },
-          "internalLocation": {
-            "$ref": "#/components/schemas/AppointmentLocationSummary"
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
-            "example": false
-          },
           "startDate": {
             "type": "string",
-            "description": "The date this appointment occurrence is taking place on",
+            "description": "The date this appointment is taking place on",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The starting time of this appointment occurrence",
+            "description": "The starting time of this appointment",
             "format": "partial-time",
             "example": "13:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The end time of this appointment occurrence",
+            "description": "The end time of this appointment",
             "format": "partial-time",
             "example": "13:30"
           },
-          "comment": {
-            "type": "string",
-            "description": "\n    Notes relating to this appointment occurrence. Can be different to the parent appointment if this occurrence has\n    been edited.\n    ",
-            "example": "This appointment occurrence has been rescheduled due to staff availability"
-          },
           "isEdited": {
             "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has been independently changed from the original state it was in when\n    it was created as part of a recurring series\n    ",
+            "description": "\n    Indicates that this appointment has been independently changed from the original state it was in when\n    it was created as part of an appointment series\n    ",
             "example": false
           },
           "isCancelled": {
             "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has been cancelled\n    ",
+            "description": "\n    Indicates that this appointment has been cancelled\n    ",
             "example": false
-          },
-          "updated": {
-            "type": "string",
-            "description": "\n    The date and time this appointment occurrence was last edited.\n    Will be null if the appointment occurrence has not been independently changed from the original state it was in when\n    it was created as part of a recurring series\n    ",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "$ref": "#/components/schemas/UserSummary"
           }
         },
-        "description": "\n  Summarises a specific appointment occurrence. Will contain copies of the parent appointment's properties unless they\n  have been changed on this appointment occurrence.\n  "
+        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  Contains the summary information of a limited set the appointment properties. N.B. does not contain \n  information on the prisoners attending this appointment to improve API performance.\n  All updates and cancellations happen at this appointment level with the parent appointment series or set being immutable.\n  "
       },
       "ActivityBasic": {
         "required": [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsApiService.kt
@@ -4,29 +4,10 @@ import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.model.Appointment
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.model.AppointmentInstance
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.model.AppointmentOccurrenceDetails
 
 @Service
 class AppointmentsApiService(@Qualifier("appointmentsApiWebClient") private val webClient: WebClient) {
-
-  suspend fun getAppointment(id: Long): Appointment {
-    return webClient.get()
-      .uri("/appointments/$id")
-      .retrieve()
-      .bodyToMono(Appointment::class.java)
-      .awaitSingle()
-  }
-
-  suspend fun getAppointmentOccurrence(id: Long): AppointmentOccurrenceDetails {
-    return webClient.get()
-      .uri("/appointment-occurrence-details/$id")
-      .retrieve()
-      .bodyToMono(AppointmentOccurrenceDetails::class.java)
-      .awaitSingle()
-  }
-
   suspend fun getAppointmentInstance(id: Long): AppointmentInstance {
     return webClient.get()
       .uri("/appointment-instances/$id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsService.kt
@@ -177,17 +177,17 @@ class AppointmentsService(
   )
 
   private fun constructComment(instance: AppointmentInstance): String? {
-    val comment = if (instance.appointmentDescription.isNullOrBlank()) {
-      if (instance.comment.isNullOrBlank()) {
+    val comment = if (instance.customName.isNullOrBlank()) {
+      if (instance.extraInformation.isNullOrBlank()) {
         null
       } else {
-        instance.comment
+        instance.extraInformation
       }
     } else {
-      if (instance.comment.isNullOrBlank()) {
-        instance.appointmentDescription
+      if (instance.extraInformation.isNullOrBlank()) {
+        instance.customName
       } else {
-        "${instance.appointmentDescription} - ${instance.comment}"
+        "${instance.customName} - ${instance.extraInformation}"
       }
     }
     return comment?.take(4000)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesServiceTest.kt
@@ -427,6 +427,7 @@ private fun newActivitySchedule(endDate: LocalDate? = null): ActivitySchedule = 
     allocated = 5,
     capacity = 10,
     onWing = false,
+    offWing = false,
   ),
   slots = emptyList(),
   startDate = LocalDate.now(),
@@ -477,4 +478,5 @@ private fun newActivity(): Activity = Activity(
     ),
   ),
   onWing = false,
+  offWing = false,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AllocationServiceTest.kt
@@ -120,6 +120,7 @@ private fun newAllocation(): Allocation {
     id = ALLOCATION_ID,
     prisonerNumber = OFFENDER_NO,
     activitySummary = "summary",
+    activityId = ACTIVITY_ID,
     bookingId = NOMIS_BOOKING_ID,
     startDate = LocalDate.parse("2023-01-12"),
     endDate = LocalDate.parse("2023-01-13"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/SchedulesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/SchedulesServiceTest.kt
@@ -251,6 +251,7 @@ private fun newScheduledInstance() = ActivityScheduleInstance(
       allocated = 5,
       capacity = 10,
       onWing = false,
+      offWing = false,
     ),
   ),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentApiServiceTest.kt
@@ -40,7 +40,7 @@ internal class AppointmentApiServiceTest {
       "inCell": false,
       "prisonerNumber": "A1234BC",
       "cancelled": false,
-      "created": "2021-03-14T10:15:00",
+      "createdTime": "2021-03-14T10:15:00",
       "createdBy": "user1"
     }
     """.trimIndent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsServiceTest.kt
@@ -105,7 +105,7 @@ internal class AppointmentsServiceTest {
   @Test
   fun `Update End time can be null`() = runTest {
     whenever(appointmentsApiService.getAppointmentInstance(APPOINTMENT_INSTANCE_ID)).thenReturn(
-      newAppointment(null, null, null),
+      newAppointmentInstance(null, null, null),
     )
     whenever(appointmentsMappingService.getMappingGivenAppointmentInstanceId(APPOINTMENT_INSTANCE_ID)).thenReturn(
       AppointmentMappingDto(APPOINTMENT_INSTANCE_ID, NOMIS_EVENT_ID),
@@ -136,7 +136,7 @@ internal class AppointmentsServiceTest {
 
   private suspend fun callService(appointmentDescription: String?, comment: String?, endTime: String? = "11:42") {
     whenever(appointmentsApiService.getAppointmentInstance(APPOINTMENT_INSTANCE_ID)).thenReturn(
-      newAppointment(appointmentDescription, comment, endTime),
+      newAppointmentInstance(appointmentDescription, comment, endTime),
     )
     whenever(nomisApiService.createAppointment(any())).thenReturn(CreateAppointmentResponse(eventId = 4567))
 
@@ -150,12 +150,12 @@ internal class AppointmentsServiceTest {
     appointmentsService.createAppointment(appointment)
   }
 
-  private fun newAppointment(appointmentDescription: String?, comment: String?, endTime: String?): AppointmentInstance =
+  private fun newAppointmentInstance(customName: String?, extraInformation: String?, endTime: String?): AppointmentInstance =
     AppointmentInstance(
       id = APPOINTMENT_INSTANCE_ID,
-      appointmentOccurrenceAllocationId = 12345,
-      appointmentOccurrenceId = 1234,
-      appointmentId = 123,
+      appointmentSeriesId = 123,
+      appointmentId = 1234,
+      appointmentAttendeeId = APPOINTMENT_INSTANCE_ID,
       appointmentType = AppointmentInstance.AppointmentType.INDIVIDUAL,
       bookingId = 12345,
       internalLocationId = 34567,
@@ -166,9 +166,9 @@ internal class AppointmentsServiceTest {
       prisonCode = "SKI",
       inCell = false,
       prisonerNumber = "A1234BC",
-      created = LocalDateTime.parse("2021-03-14T10:15:00"),
+      createdTime = LocalDateTime.parse("2021-03-14T10:15:00"),
       createdBy = "user1",
-      appointmentDescription = appointmentDescription,
-      comment = comment,
+      customName = customName,
+      extraInformation = extraInformation,
     )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsToNomisIntTest.kt
@@ -50,8 +50,8 @@ class AppointmentsToNomisIntTest : SqsIntegrationTestBase() {
       "inCell": false,
       "prisonerNumber": "A1234BC",
       "cancelled": false,
-      "comment": "Some comment",
-      "created": "2021-03-14T10:15:00",
+      "extraInformation": "Some comment",
+      "createdTime": "2021-03-14T10:15:00",
       "createdBy": "user1"
     }
   """.trimIndent()


### PR DESCRIPTION
There were some fairly substantial changes to the appointments part of the activities API. This was to bring the taxonomy in line with the UI. In brief:

- Appointment Occurrence -> Appointment - the event at a specific date, time and location
- Appointment -> Appointment Series - a collection of Appointments on a regular cadence defined by a schedule
- Bulk Appointment -> Appointment Set - a collection of Appointments taking place on the same date and in the same location but at optionally different times
- Appointment Occurrence Allocation -> Appointment Attendee - a prisoner attending a specific appointment

Additionally some key properties have been renamed to match the UI labels or an activities convention:

- appointmentDescription -> customName
- comments -> extraInformation
- created -> createdTime
- updated -> updatedTime
- cancelled -> cancelledTime

This PR updates the OpenAPI specification and makes the associated modifications to the codebase.