### PR TITLE
SDIT-1096 non-association reconciliation process

### DIFF
--- a/helm_deploy/hmpps-prisoner-to-nomis-update/templates/report-incentives-cronjob.yaml
+++ b/helm_deploy/hmpps-prisoner-to-nomis-update/templates/report-incentives-cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:
-  schedule: "0 4 * * 1"
+  schedule: "10 4 * * 1"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 600

--- a/helm_deploy/hmpps-prisoner-to-nomis-update/templates/report-non-associations-cronjob.yaml
+++ b/helm_deploy/hmpps-prisoner-to-nomis-update/templates/report-non-associations-cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:
-  schedule: "0 5 * * 1"
+  schedule: "10 4 * * 2"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 600

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsReconciliationService.kt
@@ -200,7 +200,7 @@ class NonAssociationsReconciliationService(
         }
     } else {
       dpsList.indices
-        .filter { doesNotMatch(nomisList[it], dpsList[it]) && (dpsList.size != 2 || doesNotMatch(nomisList[0], dpsList[1]))  }
+        .filter { doesNotMatch(nomisList[it], dpsList[it]) && (dpsList.size != 2 || doesNotMatch(nomisList[0], dpsList[1])) }
         .map { index ->
           val mismatch =
             MismatchNonAssociation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsResource.kt
@@ -61,6 +61,7 @@ class NonAssociationsResource(
             results.associate { "${it.id}" to "nomis=${it.nomisNonAssociation}, dps=${it.dpsNonAssociation}" }
           telemetryClient.trackEvent("non-associations-reports-reconciliation-success", map)
           log.info("Non-associations reconciliation report logged")
+          log.info("Non-associations reconciliation temp map = $map")
         }
         .onFailure {
           telemetryClient.trackEvent("non-associations-reports-reconciliation-failed")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,4 +115,4 @@ reports:
       page-size: 20
   non-associations:
     reconciliation:
-      page-size: 500
+      page-size: 100

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsReconciliationServiceTest.kt
@@ -123,47 +123,46 @@ class NonAssociationsReconciliationServiceTest {
       .isEmpty()
   }
 
-    @Test
-    fun `will report mismatch where 2 NA details have a difference`() = runTest {
-      whenever(nomisApiService.getNonAssociationDetails(OFFENDER1, OFFENDER2)).thenReturn(
-        listOf(
-          nomisResponse(1, EXP, "comment1"),
-          nomisResponse(2, EXP, "comment2"),
-        ),
-      )
+  @Test
+  fun `will report mismatch where 2 NA details have a difference`() = runTest {
+    whenever(nomisApiService.getNonAssociationDetails(OFFENDER1, OFFENDER2)).thenReturn(
+      listOf(
+        nomisResponse(1, EXP, "comment1"),
+        nomisResponse(2, EXP, "comment2"),
+      ),
+    )
 
-      whenever(nonAssociationsApiService.getNonAssociationsBetween(OFFENDER1, OFFENDER2)).thenReturn(
-        listOf(
-          dpsResponse(1L, "comment1"),
-          dpsResponse(2L, "comment3"),
-        ),
-      )
+    whenever(nonAssociationsApiService.getNonAssociationsBetween(OFFENDER1, OFFENDER2)).thenReturn(
+      listOf(
+        dpsResponse(1L, "comment1"),
+        dpsResponse(2L, "comment3"),
+      ),
+    )
 
-      assertThat(nonAssociationsReconciliationService.checkMatch(NonAssociationIdResponse(OFFENDER1, OFFENDER2)))
-        .asList()
-        .containsExactly(
-          MismatchNonAssociation(
-            NonAssociationIdResponse(OFFENDER1, OFFENDER2),
-            NonAssociationReportDetail(
-              type = "LAND",
-              createdDate = "2022-01-01",
-              expiryDate = "2022-01-01",
-              roleReason = "VIC",
-              roleReason2 = "PER",
-              comment = "comment2",
-            ),
-            NonAssociationReportDetail(
-              type = "LANDING",
-              createdDate = "2022-01-01T10:00:00",
-              closed = true,
-              roleReason = "VICTIM",
-              roleReason2 = "PERPETRATOR",
-              dpsReason = "BULLYING",
-              comment = "comment3",
-            ),
+    assertThat(nonAssociationsReconciliationService.checkMatch(NonAssociationIdResponse(OFFENDER1, OFFENDER2)))
+      .asList()
+      .containsExactly(
+        MismatchNonAssociation(
+          NonAssociationIdResponse(OFFENDER1, OFFENDER2),
+          NonAssociationReportDetail(
+            type = "LAND",
+            createdDate = "2022-01-01",
+            expiryDate = "2022-01-01",
+            roleReason = "VIC",
+            roleReason2 = "PER",
+            comment = "comment2",
           ),
-        )
-
+          NonAssociationReportDetail(
+            type = "LANDING",
+            createdDate = "2022-01-01T10:00:00",
+            closed = true,
+            roleReason = "VICTIM",
+            roleReason2 = "PERPETRATOR",
+            dpsReason = "BULLYING",
+            comment = "comment3",
+          ),
+        ),
+      )
   }
 
   private fun nomisResponse(typeSequence: Int, expiryDate: LocalDate?, comment: String? = null) = NonAssociationResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsReconciliationServiceTest.kt
@@ -48,8 +48,8 @@ class NonAssociationsReconciliationServiceTest {
           type = "LANDING",
           createdDate = "2022-01-01T10:00:00",
           closed = true,
-          roleReason = "NOT_RELEVANT",
-          roleReason2 = "NOT_RELEVANT",
+          roleReason = "VICTIM",
+          roleReason2 = "PERPETRATOR",
           dpsReason = "BULLYING",
           comment = "comment",
         ),
@@ -83,7 +83,90 @@ class NonAssociationsReconciliationServiceTest {
     )
   }
 
-  private fun nomisResponse(typeSequence: Int, expiryDate: LocalDate?) = NonAssociationResponse(
+  @Test
+  fun `will not report mismatch where NA details match`() = runTest {
+    whenever(nomisApiService.getNonAssociationDetails(OFFENDER1, OFFENDER2)).thenReturn(
+      listOf(nomisResponse(1, EXP, "comment1")),
+    )
+
+    whenever(nonAssociationsApiService.getNonAssociationsBetween(OFFENDER1, OFFENDER2)).thenReturn(
+      listOf(dpsResponse(1L, "comment1")),
+    )
+
+    assertThat(nonAssociationsReconciliationService.checkMatch(NonAssociationIdResponse(OFFENDER1, OFFENDER2)))
+      .asList()
+      .isEmpty()
+  }
+  /*
+  nomisNonAssociation=NonAssociationReportDetail(type=LAND, createdDate=2022-01-01, expiryDate=2022-01-01, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=comment1),
+  dpsNonAssociation=NonAssociationReportDetail(type=LANDING, createdDate=2022-01-01T10:00:00, expiryDate=, closed=true, roleReason=NOT_RELEVANT, roleReason2=NOT_RELEVANT, dpsReason=BULLYING, comment=comment1))]
+   */
+
+  @Test
+  fun `will not report mismatch where 2 NA details are swapped`() = runTest {
+    whenever(nomisApiService.getNonAssociationDetails(OFFENDER1, OFFENDER2)).thenReturn(
+      listOf(
+        nomisResponse(1, EXP, "comment1"),
+        nomisResponse(2, EXP, "comment2"),
+      ),
+    )
+
+    whenever(nonAssociationsApiService.getNonAssociationsBetween(OFFENDER1, OFFENDER2)).thenReturn(
+      listOf(
+        dpsResponse(1L, "comment2"),
+        dpsResponse(2L, "comment1"),
+      ),
+    )
+
+    assertThat(nonAssociationsReconciliationService.checkMatch(NonAssociationIdResponse(OFFENDER1, OFFENDER2)))
+      .asList()
+      .isEmpty()
+  }
+
+    @Test
+    fun `will report mismatch where 2 NA details have a difference`() = runTest {
+      whenever(nomisApiService.getNonAssociationDetails(OFFENDER1, OFFENDER2)).thenReturn(
+        listOf(
+          nomisResponse(1, EXP, "comment1"),
+          nomisResponse(2, EXP, "comment2"),
+        ),
+      )
+
+      whenever(nonAssociationsApiService.getNonAssociationsBetween(OFFENDER1, OFFENDER2)).thenReturn(
+        listOf(
+          dpsResponse(1L, "comment1"),
+          dpsResponse(2L, "comment3"),
+        ),
+      )
+
+      assertThat(nonAssociationsReconciliationService.checkMatch(NonAssociationIdResponse(OFFENDER1, OFFENDER2)))
+        .asList()
+        .containsExactly(
+          MismatchNonAssociation(
+            NonAssociationIdResponse(OFFENDER1, OFFENDER2),
+            NonAssociationReportDetail(
+              type = "LAND",
+              createdDate = "2022-01-01",
+              expiryDate = "2022-01-01",
+              roleReason = "VIC",
+              roleReason2 = "PER",
+              comment = "comment2",
+            ),
+            NonAssociationReportDetail(
+              type = "LANDING",
+              createdDate = "2022-01-01T10:00:00",
+              closed = true,
+              roleReason = "VICTIM",
+              roleReason2 = "PERPETRATOR",
+              dpsReason = "BULLYING",
+              comment = "comment3",
+            ),
+          ),
+        )
+
+  }
+
+  private fun nomisResponse(typeSequence: Int, expiryDate: LocalDate?, comment: String? = null) = NonAssociationResponse(
     OFFENDER1,
     OFFENDER2,
     typeSequence,
@@ -92,21 +175,22 @@ class NonAssociationsReconciliationServiceTest {
     "LAND",
     effectiveDate = LocalDate.parse("2022-01-01"),
     expiryDate = expiryDate,
+    comment = comment,
   )
 
-  private fun dpsResponse(id: Long) = NonAssociation(
+  private fun dpsResponse(id: Long, comment: String = "comment") = NonAssociation(
     id,
     OFFENDER1,
-    NonAssociation.FirstPrisonerRole.NOT_RELEVANT,
+    NonAssociation.FirstPrisonerRole.VICTIM,
     "roledesc",
     OFFENDER2,
-    NonAssociation.SecondPrisonerRole.NOT_RELEVANT,
+    NonAssociation.SecondPrisonerRole.PERPETRATOR,
     "roledesc",
     NonAssociation.Reason.BULLYING,
     "reasondesc",
     NonAssociation.RestrictionType.LANDING,
     "typedesc",
-    comment = "comment",
+    comment = comment,
     whenCreated = "2022-01-01T10:00:00",
     whenUpdated = "2022-01-01T10:00:00",
     updatedBy = "me",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/nonassociations/NonAssociationsResourceIntTest.kt
@@ -231,40 +231,46 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
           assertThat(it).containsEntry("mismatch-count", "6")
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0010TY, offenderNo2=B0010TZ)",
-            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)," +
-              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)," +
+              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0020TY, offenderNo2=B0020TZ)",
-            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)," +
-              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)," +
+              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0030TY, offenderNo2=B0030TZ)",
-            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)," +
-              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)," +
+              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0035TY, offenderNo2=B0035TZ)",
             "nomis=null," +
-              " dps=NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+              " dps=NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0036TY, offenderNo2=B0036TZ)",
             "nomis=null," +
-              " dps=NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+              " dps=NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0037TY, offenderNo2=B0037TZ)",
             "nomis=null," +
-              " dps=NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+              " dps=NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
         },
         isNull(),
       )
 
-      verify(telemetryClient, times(6)).trackEvent(
+      verify(telemetryClient, times(3)).trackEvent(
         eq("non-associations-reports-reconciliation-mismatch"),
+        telemetryCaptor.capture(),
+        isNull(),
+      )
+
+      verify(telemetryClient, times(3)).trackEvent(
+        eq("non-associations-reports-reconciliation-dps-only"),
         telemetryCaptor.capture(),
         isNull(),
       )
@@ -274,11 +280,11 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
         assertThat(this).containsEntry("offenderNo2", "B0010TZ")
         assertThat(this).containsEntry(
           "nomis",
-          "NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)",
+          "NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)",
         )
         assertThat(this).containsEntry(
           "dps",
-          "NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+          "NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
         )
       }
       with(telemetryCaptor.allValues[1]) {
@@ -286,11 +292,11 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
         assertThat(this).containsEntry("offenderNo2", "B0020TZ")
         assertThat(this).containsEntry(
           "nomis",
-          "NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)",
+          "NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)",
         )
         assertThat(this).containsEntry(
           "dps",
-          "NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+          "NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
         )
       }
       with(telemetryCaptor.allValues[2]) {
@@ -298,11 +304,11 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
         assertThat(this).containsEntry("offenderNo2", "B0030TZ")
         assertThat(this).containsEntry(
           "nomis",
-          "NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)",
+          "NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)",
         )
         assertThat(this).containsEntry(
           "dps",
-          "NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+          "NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
         )
       }
       with(telemetryCaptor.allValues[3]) {
@@ -311,7 +317,7 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
         assertThat(this).doesNotContainKey("nomis")
         assertThat(this).containsEntry(
           "dps",
-          "NonAssociation(id=999, firstPrisonerNumber=A0035TY, firstPrisonerRole=VICTIM, firstPrisonerRoleDescription=Victim, secondPrisonerNumber=B0035TZ, secondPrisonerRole=PERPETRATOR, secondPrisonerRoleDescription=Perpetrator, reason=BULLYING, reasonDescription=Bullying, restrictionType=CELL, restrictionTypeDescription=Cell only, comment=Fight on Wing C, whenCreated=2023-08-25T10:55:04, whenUpdated=2023-08-25T10:55:04, updatedBy=OFF3_GEN, isClosed=false, isOpen=true, closedBy=null, closedReason=null, closedAt=null)",
+          "NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
         )
       }
       with(telemetryCaptor.allValues[4]) {
@@ -319,7 +325,7 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
         assertThat(this).containsEntry("offenderNo2", "B0036TZ")
         assertThat(this).containsEntry(
           "dps",
-          "NonAssociation(id=999, firstPrisonerNumber=A0036TY, firstPrisonerRole=VICTIM, firstPrisonerRoleDescription=Victim, secondPrisonerNumber=B0036TZ, secondPrisonerRole=PERPETRATOR, secondPrisonerRoleDescription=Perpetrator, reason=BULLYING, reasonDescription=Bullying, restrictionType=CELL, restrictionTypeDescription=Cell only, comment=Fight on Wing C, whenCreated=2023-08-25T10:55:04, whenUpdated=2023-08-25T10:55:04, updatedBy=OFF3_GEN, isClosed=false, isOpen=true, closedBy=null, closedReason=null, closedAt=null)",
+          "NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
         )
       }
       with(telemetryCaptor.allValues[5]) {
@@ -327,7 +333,7 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
         assertThat(this).containsEntry("offenderNo2", "B0037TZ")
         assertThat(this).containsEntry(
           "dps",
-          "NonAssociation(id=999, firstPrisonerNumber=A0037TY, firstPrisonerRole=VICTIM, firstPrisonerRoleDescription=Victim, secondPrisonerNumber=B0037TZ, secondPrisonerRole=PERPETRATOR, secondPrisonerRoleDescription=Perpetrator, reason=BULLYING, reasonDescription=Bullying, restrictionType=CELL, restrictionTypeDescription=Cell only, comment=Fight on Wing C, whenCreated=2023-08-25T10:55:04, whenUpdated=2023-08-25T10:55:04, updatedBy=OFF3_GEN, isClosed=false, isOpen=true, closedBy=null, closedReason=null, closedAt=null)",
+          "NonAssociationReportDetail(type=CELL, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
         )
       }
     }
@@ -355,13 +361,13 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
           assertThat(it).containsEntry("mismatch-count", "5")
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0010TY, offenderNo2=B0010TZ)",
-            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)," +
-              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)," +
+              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0030TY, offenderNo2=B0030TZ)",
-            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)," +
-              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)," +
+              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
         },
         isNull(),
@@ -400,13 +406,13 @@ class NonAssociationsResourceIntTest : IntegrationTestBase() {
           assertThat(it).containsEntry("mismatch-count", "5")
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0010TY, offenderNo2=B0010TZ)",
-            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)," +
-              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)," +
+              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
           assertThat(it).containsEntry(
             "NonAssociationIdResponse(offenderNo1=A0020TY, offenderNo2=B0020TZ)",
-            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=, comment=Fight on Wing C)," +
-              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
+            "nomis=NonAssociationReportDetail(type=LAND, createdDate=2023-08-25, expiryDate=2023-10-26, closed=null, roleReason=VIC, roleReason2=PER, dpsReason=null, comment=Fight on Wing C)," +
+              " dps=NonAssociationReportDetail(type=WING, createdDate=2023-08-25T10:55:04, expiryDate=null, closed=false, roleReason=VICTIM, roleReason2=PERPETRATOR, dpsReason=BULLYING, comment=Fight on Wing C)",
           )
         },
         isNull(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NonAssociationsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NonAssociationsApiMockServer.kt
@@ -98,7 +98,7 @@ class NonAssociationsApiMockServer : WireMockServer(WIREMOCK_PORT) {
       post(urlPathEqualTo("/non-associations/between"))
         .withRequestBody(WireMock.equalToJson("""["$offender1","$offender2"]"""))
         .willReturn(jsonResponse("""{ "error": "some error" }""", status)),
-      )
+    )
   }
 
   fun stubGetNonAssociationsPage(pageNumber: Long, pageSize: Long = 100, response: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NonAssociationsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NonAssociationsApiMockServer.kt
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.jsonResponse
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
@@ -39,33 +40,20 @@ class NonAssociationsApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun stubHealthPing(status: Int) {
     stubFor(
-      get("/health/ping").willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(if (status == 200) "pong" else "some error")
-          .withStatus(status),
-      ),
+      get("/health/ping").willReturn(okJson(if (status == 200) "pong" else "some error")),
     )
   }
 
   fun stubGetNonAssociation(id: Long, response: String) {
     stubFor(
-      get("/legacy/api/non-associations/$id").willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(response)
-          .withStatus(200),
-      ),
+      get("/legacy/api/non-associations/$id").willReturn(okJson(response)),
     )
   }
 
   fun stubGetNonAssociationWithError(id: Long, status: Int = 500) {
     stubFor(
       get("/legacy/api/non-associations/$id").willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody("""{ "error": "some error" }""")
-          .withStatus(status),
+        jsonResponse("""{ "error": "some error" }""", status),
       ),
     )
   }
@@ -109,13 +97,8 @@ class NonAssociationsApiMockServer : WireMockServer(WIREMOCK_PORT) {
     stubFor(
       post(urlPathEqualTo("/non-associations/between"))
         .withRequestBody(WireMock.equalToJson("""["$offender1","$offender2"]"""))
-        .willReturn(
-          aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withBody("""{ "error": "some error" }""")
-            .withStatus(status),
-        ),
-    )
+        .willReturn(jsonResponse("""{ "error": "some error" }""", status)),
+      )
   }
 
   fun stubGetNonAssociationsPage(pageNumber: Long, pageSize: Long = 100, response: String) {
@@ -125,6 +108,16 @@ class NonAssociationsApiMockServer : WireMockServer(WIREMOCK_PORT) {
         .withQueryParam("page", WireMock.equalTo(pageNumber.toString()))
         .withQueryParam("size", WireMock.equalTo(pageSize.toString()))
         .willReturn(okJson(response)),
+    )
+  }
+
+  fun stubGetNonAssociationsPageWithError(pageNumber: Long, pageSize: Long = 100, status: Int = 500) {
+    stubFor(
+      get(urlPathEqualTo("/non-associations"))
+        .withQueryParam("includeClosed", WireMock.equalTo("true"))
+        .withQueryParam("page", WireMock.equalTo(pageNumber.toString()))
+        .withQueryParam("size", WireMock.equalTo(pageSize.toString()))
+        .willReturn(jsonResponse("""{ "error": "some error" }""", status)),
     )
   }
 


### PR DESCRIPTION
Relax comparison to ignore dps reason,
decrease the page size to 100,
avoid swapped NA details with same date