### PR TITLE
SDIT-1241 ignore adjudicator names that are just blank

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsService.kt
@@ -1067,7 +1067,7 @@ private fun toNomisPleaCode(plea: HearingOutcomeDto.Plea) = when (plea) {
 private fun getAdjudicatorUsernameForInternalHearingOnly(hearingType: String, adjudicator: String) =
   when (hearingType) {
     HearingDto.OicHearingType.INAD_ADULT.name, HearingDto.OicHearingType.INAD_YOI.name -> null
-    else -> adjudicator
+    else -> adjudicator.takeIf { it.isNotBlank() }
   }
 
 private fun HearingAdditionalInformation.toTelemetryMap(): MutableMap<String, String> = mutableMapOf(


### PR DESCRIPTION
Blank names were being sent to NOMIS API which breaks, null is allowed so marshall this to null.