### PR TITLE
SDIT-1264 Filter DPS adjustments by booking until they fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingReconciliationService.kt
@@ -57,7 +57,11 @@ class SentencingReconciliationService(
   suspend fun checkBookingAdjustmentsMatch(prisonerId: ActivePrisonerId): MismatchSentencingAdjustments? = runCatching {
     val (nomisAdjustments, dpsAdjustments) = withContext(Dispatchers.Unconfined) {
       async { nomisApiService.getAdjustments(prisonerId.bookingId) } to
-        async { adjustmentsApiService.getAdjustments(prisonerId.offenderNo) }
+        async {
+          adjustmentsApiService.getAdjustments(prisonerId.offenderNo)
+            // temporary fix until DPS filter out old adjustments
+            ?.filter { it.bookingId == prisonerId.bookingId }
+        }
     }.awaitBoth()
 
     val nomisCounts: AdjustmentCounts = nomisAdjustments.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingReconciliationServiceTest.kt
@@ -117,7 +117,7 @@ internal class SentencingReconciliationServiceTest {
         assertThat(
           service.checkBookingAdjustmentsMatch(
             ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = "offenderNo",
             ),
           ),
@@ -152,7 +152,7 @@ internal class SentencingReconciliationServiceTest {
         assertThat(
           service.checkBookingAdjustmentsMatch(
             ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = offenderNo,
             ),
           ),
@@ -187,7 +187,7 @@ internal class SentencingReconciliationServiceTest {
         assertThat(
           service.checkBookingAdjustmentsMatch(
             ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = offenderNo,
             ),
           ),
@@ -238,14 +238,14 @@ internal class SentencingReconciliationServiceTest {
         assertThat(
           service.checkBookingAdjustmentsMatch(
             ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = offenderNo,
             ),
           ),
         ).isEqualTo(
           MismatchSentencingAdjustments(
             prisonerId = ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = offenderNo,
             ),
             dpsCounts = AdjustmentCounts(
@@ -316,14 +316,14 @@ internal class SentencingReconciliationServiceTest {
         assertThat(
           service.checkBookingAdjustmentsMatch(
             ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = offenderNo,
             ),
           ),
         ).isEqualTo(
           MismatchSentencingAdjustments(
             prisonerId = ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = offenderNo,
             ),
             dpsCounts = AdjustmentCounts(
@@ -385,14 +385,14 @@ internal class SentencingReconciliationServiceTest {
         assertThat(
           service.checkBookingAdjustmentsMatch(
             ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = offenderNo,
             ),
           ),
         ).isEqualTo(
           MismatchSentencingAdjustments(
             prisonerId = ActivePrisonerId(
-              bookingId = bookingId,
+              bookingId = adjustmentBookingId,
               offenderNo = offenderNo,
             ),
             dpsCounts = AdjustmentCounts(
@@ -431,7 +431,7 @@ internal class SentencingReconciliationServiceTest {
       sentencingAdjustmentsApi.stubAdjustmentsGet(
         offenderNo = "A0001TZ",
         listOf(
-          adjustment(AdjustmentType.LAWFULLY_AT_LARGE),
+          adjustment(AdjustmentType.LAWFULLY_AT_LARGE, bookingId = 1),
         ),
       )
       nomisApi.stubGetSentencingAdjustments(
@@ -449,7 +449,7 @@ internal class SentencingReconciliationServiceTest {
       sentencingAdjustmentsApi.stubAdjustmentsGet(
         offenderNo = "A0002TZ",
         listOf(
-          adjustment(AdjustmentType.UNLAWFULLY_AT_LARGE),
+          adjustment(AdjustmentType.UNLAWFULLY_AT_LARGE, bookingId = 2),
         ),
       )
       nomisApi.stubGetSentencingAdjustments(
@@ -522,6 +522,7 @@ internal fun adjustment(
   adjustmentType: AdjustmentType,
   fromDate: LocalDate = LocalDate.now(),
   effectiveDays: Int = 5,
+  bookingId: Long = adjustmentBookingId,
 ) = AdjustmentDto(
   id = UUID.fromString("0102ab0f-69b0-4292-84d9-bc5fd9f46e66"),
   bookingId = bookingId,
@@ -543,7 +544,7 @@ internal fun keyDateAdjustment(
 ) = KeyDateAdjustmentResponse(
   id = 123456L,
   offenderNo = offenderNo,
-  bookingId = bookingId,
+  bookingId = adjustmentBookingId,
   adjustmentType = adjustmentType.value,
   adjustmentDate = fromDate,
   adjustmentFromDate = fromDate,
@@ -561,7 +562,7 @@ internal fun sentenceAdjustment(
   id = 123456L,
   sentenceSequence = 1,
   offenderNo = offenderNo,
-  bookingId = bookingId,
+  bookingId = adjustmentBookingId,
   adjustmentType = adjustmentType.value,
   adjustmentDate = fromDate,
   adjustmentFromDate = fromDate,
@@ -572,8 +573,8 @@ internal fun sentenceAdjustment(
   comment = null,
 )
 
-private const val bookingId = 123456L
-private const val offenderNo = "A1234AA"
+const val adjustmentBookingId = 123456L
+const val offenderNo = "A1234AA"
 
 sealed class SentenceAdjustments(val value: SentencingAdjustmentType) {
   data object RSR : SentenceAdjustments(SentencingAdjustmentType("RSR", "Recall Sentence Remand"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingResourceIntTest.kt
@@ -35,6 +35,7 @@ class SentencingResourceIntTest : IntegrationTestBase() {
     @BeforeEach
     fun setUp() {
       reset(telemetryClient)
+      offenderNo
 
       val numberOfActivePrisoners = 34L
       nomisApi.stubGetActivePrisonersInitialCount(numberOfActivePrisoners)
@@ -45,9 +46,9 @@ class SentencingResourceIntTest : IntegrationTestBase() {
 
       // mock non-matching for first and last prisoners
       nomisApi.stubGetSentencingAdjustments(1, SentencingAdjustmentsResponse(emptyList(), emptyList()))
-      sentencingAdjustmentsApi.stubAdjustmentsGet("A0001TZ", listOf(adjustment(adjustmentType = AdjustmentDto.AdjustmentType.REMAND)))
+      sentencingAdjustmentsApi.stubAdjustmentsGet("A0001TZ", listOf(adjustment(adjustmentType = AdjustmentDto.AdjustmentType.REMAND, bookingId = 1)))
       nomisApi.stubGetSentencingAdjustments(34, SentencingAdjustmentsResponse(emptyList(), listOf(sentenceAdjustment(adjustmentType = SentenceAdjustments.S240A))))
-      sentencingAdjustmentsApi.stubAdjustmentsGet("A0034TZ", listOf(adjustment(adjustmentType = AdjustmentDto.AdjustmentType.UNLAWFULLY_AT_LARGE)))
+      sentencingAdjustmentsApi.stubAdjustmentsGet("A0034TZ", listOf(adjustment(adjustmentType = AdjustmentDto.AdjustmentType.UNLAWFULLY_AT_LARGE, bookingId = 34)))
       // all others have no adjustments so match
       (2..<numberOfActivePrisoners).forEach {
         nomisApi.stubGetSentencingAdjustments(it, SentencingAdjustmentsResponse(emptyList(), emptyList()))


### PR DESCRIPTION
DPS is incorrectly returning old adjustments that are no longer relevant, they will fix this - but for now we just filter by bookingId