### PR TITLE
SDIT-1264 Initial draft of adjudication reconciliation

### DIFF
--- a/openapi-specs/nomis-sync-api-docs.json
+++ b/openapi-specs/nomis-sync-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2023-12-13.5851.d58d6da"
+    "version": "2023-12-15.5883.a3a318a"
   },
   "servers": [
     {
@@ -2757,6 +2757,159 @@
         }
       }
     },
+    "/prisoners/{offenderNo}/sentencing/court-cases": {
+      "get": {
+        "tags": [
+          "sentencing-resource"
+        ],
+        "summary": "get court cases for an offender",
+        "description": "Requires role NOMIS_SENTENCING. Retrieves a court case by id",
+        "operationId": "getCourtCasesByOffender",
+        "parameters": [
+          {
+            "name": "offenderNo",
+            "in": "path",
+            "description": "Offender No",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Offender No",
+              "example": "AA12345"
+            },
+            "example": "AA12345"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the list of court cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CourtCaseResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint when role NOMIS_SENTENCING not present",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Offender not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "sentencing-resource"
+        ],
+        "summary": "Creates a new Court Case",
+        "description": "Required role NOMIS_SENTENCING Creates a new Court Case for the offender and latest booking",
+        "operationId": "createCourtCase",
+        "parameters": [
+          {
+            "name": "offenderNo",
+            "in": "path",
+            "description": "Booking Id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Booking Id",
+              "example": 12345
+            },
+            "example": 12345
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCourtCaseRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created Court case",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateCourtCaseResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Supplied data is invalid, for instance missing required fields or invalid values. See schema for details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint when role NOMIS_SENTENCING not present",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Offender does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/prisoners/{offenderNo}/adjudications": {
       "post": {
         "tags": [
@@ -4298,75 +4451,6 @@
         }
       }
     },
-    "/prisoners/{offenderNo}/sentencing/court-cases": {
-      "get": {
-        "tags": [
-          "sentencing-resource"
-        ],
-        "summary": "get court cases for an offender",
-        "description": "Requires role NOMIS_SENTENCING. Retrieves a court case by id",
-        "operationId": "getCourtCasesByOffender",
-        "parameters": [
-          {
-            "name": "offenderNo",
-            "in": "path",
-            "description": "Offender No",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Offender No",
-              "example": "AA12345"
-            },
-            "example": "AA12345"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "the list of court cases",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CourtCaseResponse"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized to access this endpoint",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden to access this endpoint when role NOMIS_SENTENCING not present",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Offender not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/prisoners/{offenderNo}/sentencing/court-cases/{id}": {
       "get": {
         "tags": [
@@ -4777,6 +4861,72 @@
           },
           "404": {
             "description": "Hearing result award does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prisoners/booking-id/{bookingId}/awards/ada/summary": {
+      "get": {
+        "tags": [
+          "adjudication-resource"
+        ],
+        "summary": "Get ADA award summary result award by booking ",
+        "description": "Retrieves a summary of ADA awards along with associated adjudication for a given booking. Requires ROLE_NOMIS_ADJUDICATIONS",
+        "operationId": "getAdjudicationADASummary",
+        "parameters": [
+          {
+            "name": "bookingId",
+            "in": "path",
+            "description": "NOMIS booking Id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "NOMIS booking Id",
+              "example": 12345
+            },
+            "example": 12345
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ADA Summary award Information Returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdjudicationADAAwardSummaryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint. Requires ROLE_NOMIS_ADJUDICATIONS",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Booking does not exist",
             "content": {
               "application/json": {
                 "schema": {
@@ -7925,6 +8075,48 @@
         },
         "description": "Visit creation response"
       },
+      "CreateCourtCaseRequest": {
+        "required": [
+          "court",
+          "legalCaseType",
+          "startDate",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "description": "Court case start date",
+            "format": "date"
+          },
+          "legalCaseType": {
+            "type": "string",
+            "description": "Legal Case type"
+          },
+          "court": {
+            "type": "string",
+            "description": "Court Id (establishment)"
+          },
+          "status": {
+            "type": "string",
+            "description": "Case status"
+          }
+        },
+        "description": "Court case create request"
+      },
+      "CreateCourtCaseResponse": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "description": "Create adjustment response"
+      },
       "AdjudicationCharge": {
         "required": [
           "chargeSequence",
@@ -9604,15 +9796,15 @@
           "bookingId",
           "caseSequence",
           "caseStatus",
-          "caseType",
           "courtEvents",
           "createdByUsername",
           "createdDateTime",
+          "establishmentId",
           "id",
+          "legalCaseType",
           "lidsCaseNumber",
           "offenderCharges",
-          "offenderNo",
-          "prisonId"
+          "offenderNo"
         ],
         "type": "object",
         "properties": {
@@ -9637,14 +9829,14 @@
           "caseStatus": {
             "$ref": "#/components/schemas/CodeDescription"
           },
-          "caseType": {
+          "legalCaseType": {
             "$ref": "#/components/schemas/CodeDescription"
           },
           "beginDate": {
             "type": "string",
             "format": "date"
           },
-          "prisonId": {
+          "establishmentId": {
             "type": "string"
           },
           "combinedCaseId": {
@@ -10426,6 +10618,78 @@
           }
         },
         "description": "Sentencing adjustment"
+      },
+      "ADASummary": {
+        "required": [
+          "adjudicationNumber",
+          "days",
+          "effectiveDate",
+          "sanctionSequence",
+          "sanctionStatus"
+        ],
+        "type": "object",
+        "properties": {
+          "adjudicationNumber": {
+            "type": "integer",
+            "description": "Parent adjudication number that lead to this award",
+            "format": "int64"
+          },
+          "sanctionSequence": {
+            "type": "integer",
+            "description": "Key to this sanction",
+            "format": "int32"
+          },
+          "days": {
+            "type": "integer",
+            "description": "Number of days awards",
+            "format": "int32"
+          },
+          "effectiveDate": {
+            "type": "string",
+            "description": "Date of award",
+            "format": "date"
+          },
+          "sanctionStatus": {
+            "$ref": "#/components/schemas/CodeDescription"
+          }
+        },
+        "description": "ADA summary"
+      },
+      "AdjudicationADAAwardSummaryResponse": {
+        "required": [
+          "adaSummaries",
+          "bookingId",
+          "offenderNo",
+          "prisonIds"
+        ],
+        "type": "object",
+        "properties": {
+          "bookingId": {
+            "type": "integer",
+            "description": "Booking id for the summary",
+            "format": "int64"
+          },
+          "offenderNo": {
+            "type": "string",
+            "description": "Prisoner number related to booking"
+          },
+          "prisonIds": {
+            "type": "array",
+            "description": "List of prisons this person attended during this booking",
+            "items": {
+              "type": "string",
+              "description": "List of prisons this person attended during this booking"
+            }
+          },
+          "adaSummaries": {
+            "type": "array",
+            "description": "List of ADAs awarded during this booking period",
+            "items": {
+              "$ref": "#/components/schemas/ADASummary"
+            }
+          }
+        },
+        "description": "Summary of adjudication for a booking"
       },
       "NonAssociationResponse": {
         "required": [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsApiService.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.PageReportedAdjudicationDto
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.ReportedAdjudicationDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.ReportedAdjudicationResponse
 
 @Service
@@ -14,5 +16,13 @@ class AdjudicationsApiService(private val adjudicationsApiWebClient: WebClient) 
       .header("Active-Caseload", prisonId)
       .retrieve()
       .awaitBody()
+  }
+
+  suspend fun getAdjudicationsByBookingId(bookingId: Long, prisonIds: List<String>): List<ReportedAdjudicationDto> {
+    // TODO - switch to simplified non-paged version when available
+    return adjudicationsApiWebClient.get()
+      .uri("/reported-adjudications/booking/{bookingId}?agency={agency}&page={page}&size={size}", bookingId, prisonIds.joinToString(), 0, 1000)
+      .retrieve()
+      .awaitBody<PageReportedAdjudicationDto>().content!!
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationService.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications
+
+import com.microsoft.applicationinsights.TelemetryClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withContext
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.ActivePrisonerId
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.asPages
+
+@Service
+class AdjudicationsReconciliationService(
+  private val telemetryClient: TelemetryClient,
+  private val nomisApiService: NomisApiService,
+  private val adjudicationsApiService: AdjudicationsApiService,
+  @Value("\${reports.sentencing.reconciliation.page-size}")
+  private val pageSize: Long = 20,
+) {
+  private companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  suspend fun generateReconciliationReport(activePrisonersCount: Long): List<MismatchAdjudicationAdaPunishments> {
+    return activePrisonersCount.asPages(pageSize).flatMap { page ->
+      val activePrisoners = getActivePrisonersForPage(page)
+
+      withContext(Dispatchers.Unconfined) {
+        activePrisoners.map { async { checkADAPunishmentsMatch(it) } }
+      }.awaitAll().filterNotNull()
+    }
+  }
+
+  private suspend fun getActivePrisonersForPage(page: Pair<Long, Long>) =
+    runCatching { nomisApiService.getActivePrisoners(page.first, page.second).content }
+      .onFailure {
+        telemetryClient.trackEvent(
+          "adjudication-reports-reconciliation-mismatch-page-error",
+          mapOf(
+            "page" to page.first.toString(),
+          ),
+        )
+        log.error("Unable to match entire page of prisoners: $page", it)
+      }
+      .getOrElse { emptyList() }
+      .also { log.info("Page requested: $page, with ${it.size} active prisoners") }
+
+  suspend fun checkADAPunishmentsMatch(prisonerId: ActivePrisonerId): MismatchAdjudicationAdaPunishments? = runCatching {
+    val nomisSummary = nomisApiService.getAdaAwardsSummary(prisonerId.bookingId)
+    val dpsAdjudications = adjudicationsApiService.getAdjudicationsByBookingId(prisonerId.bookingId, nomisSummary.prisonIds)
+
+    // TODO matching
+    return null
+  }.onFailure {
+    log.error("Unable to match adjudication for prisoner with ${prisonerId.offenderNo} booking: ${prisonerId.bookingId}", it)
+    telemetryClient.trackEvent(
+      "adjudication-reports-reconciliation-mismatch-error",
+      mapOf(
+        "offenderNo" to prisonerId.offenderNo,
+        "bookingId" to prisonerId.bookingId.toString(),
+      ),
+    )
+  }.getOrNull()
+}
+
+data class MismatchAdjudicationAdaPunishments(
+  val prisonerId: ActivePrisonerId,
+  val dpsAdas: AdaSummary,
+  val nomisAda: AdaSummary,
+)
+
+data class AdaSummary(
+  val count: Int = 0,
+  val days: Int = 0,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
@@ -20,6 +20,7 @@ import org.springframework.web.reactive.function.client.awaitBody
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyOrNullForNotFound
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyOrUpsertAttendanceError
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AdjudicationADAAwardSummaryResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AdjudicationResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AllocationReconciliationResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AttendanceReconciliationResponse
@@ -536,6 +537,12 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
     .bodyValue(request)
     .retrieve()
     .awaitBodilessEntity()
+
+  suspend fun getAdaAwardsSummary(bookingId: Long): AdjudicationADAAwardSummaryResponse =
+    webClient.get()
+      .uri("/prisoners/booking-id/{bookingId}/awards/ada/summary", bookingId)
+      .retrieve()
+      .awaitBody()
 
   // ////////// NON-ASSOCIATIONS //////////////
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationServiceTest.kt
@@ -1,0 +1,97 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications
+
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.microsoft.applicationinsights.TelemetryClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.SpringAPIServiceTest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AdjudicationADAAwardSummaryResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.ActivePrisonerId
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.AdjudicationsApiExtension.Companion.adjudicationsApiServer
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.NomisApiExtension.Companion.nomisApi
+
+@SpringAPIServiceTest
+@Import(
+  AdjudicationsReconciliationService::class,
+  NomisApiService::class,
+  AdjudicationsApiService::class,
+  AdjudicationsConfiguration::class,
+)
+internal class AdjudicationsReconciliationServiceTest {
+  @MockBean
+  lateinit var telemetryClient: TelemetryClient
+
+  @Autowired
+  private lateinit var service: AdjudicationsReconciliationService
+
+  @Nested
+  inner class CheckBookingAdaPunishmentsMatch {
+
+    @Nested
+    inner class WhenBothSystemsHaveNoAdas {
+      @BeforeEach
+      fun beforeEach() {
+        adjudicationsApiServer.stubGetAdjudicationsByBookingId(123456, emptyList())
+        nomisApi.stubGetAdaAwardSummary(
+          bookingId = 123456,
+          adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
+            bookingId = 123456,
+            offenderNo = "A1234AA",
+            prisonIds = listOf("MDI"),
+            adaSummaries = emptyList(),
+          ),
+        )
+      }
+
+      @Test
+      fun `will not report a mismatch`() = runTest {
+        assertThat(
+          service.checkADAPunishmentsMatch(
+            ActivePrisonerId(
+              bookingId = 123456L,
+              offenderNo = "A1234AA",
+            ),
+          ),
+        ).isNull()
+      }
+    }
+  }
+
+  @Nested
+  inner class GenerateReconciliationReport {
+    @BeforeEach
+    fun setUp() {
+      nomisApi.stubGetActivePrisonersInitialCount(1)
+      nomisApi.stubGetActivePrisonersPage(1, 0, 1)
+      adjudicationsApiServer.stubGetAdjudicationsByBookingId(1, emptyList())
+      nomisApi.stubGetAdaAwardSummary(
+        bookingId = 1,
+        adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(bookingId = 1, offenderNo = "A1234AA", prisonIds = listOf("MDI"), adaSummaries = emptyList()),
+      )
+    }
+
+    @Test
+    fun `will call DPS for each bookingId`() = runTest {
+      service.generateReconciliationReport(1)
+      adjudicationsApiServer.verify(getRequestedFor(urlPathEqualTo("/reported-adjudications/booking/1")))
+    }
+
+    @Test
+    fun `will call NOMIS for each bookingId`() = runTest {
+      service.generateReconciliationReport(1)
+      nomisApi.verify(getRequestedFor(urlEqualTo("/prisoners/booking-id/1/awards/ada/summary")))
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiServiceTest.kt
@@ -1619,6 +1619,30 @@ internal class NomisApiServiceTest {
       )
     }
   }
+
+  @Nested
+  inner class GetAdaAwardSummary {
+    @Test
+    fun `should call nomis api with OAuth2 token`() = runTest {
+      nomisApi.stubGetAdaAwardSummary(123456)
+
+      nomisApiService.getAdaAwardsSummary(123456)
+
+      nomisApi.verify(
+        getRequestedFor(urlEqualTo("/prisoners/booking-id/123456/awards/ada/summary"))
+          .withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    fun `should throw exception on any error`() = runTest {
+      nomisApi.stubGetAdaAwardSummaryWithError(123456, status = 404)
+
+      assertThrows<NotFound> {
+        nomisApiService.getAdaAwardsSummary(123456)
+      }
+    }
+  }
 }
 
 fun newVisit(offenderNo: String = "AB123D"): CreateVisitDto = CreateVisitDto(


### PR DESCRIPTION
A new service, AdjudicationsReconciliationService, has been added to reconcile adjudications between the old and new systems. This includes methods to generate reconciliation reports and check if adjudication punishments match. The Nomis API documentation has also been updated to reflect newly added endpoints related to this service. Corresponding unit tests have been added to ensure the correctness of this service.