### PR TITLE
SDIT-1469 Temporarily increase max response size

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   application:
     name: hmpps-prisoner-to-nomis-update
   codec:
-    max-in-memory-size: 10MB
+    max-in-memory-size: 20MB
 
   security:
     oauth2:


### PR DESCRIPTION
Until we put a proper fix in - call a better endpoint for `/activities/{activityId}` that doesn't return all the schedules.