### PR TITLE
SDIT-1453 Remove prisonIds from NOMIS API getAdaSwardsSummary

### DIFF
--- a/openapi-specs/nomis-sync-api-docs.json
+++ b/openapi-specs/nomis-sync-api-docs.json
@@ -10673,14 +10673,6 @@
             "type": "string",
             "description": "Prisoner number related to booking"
           },
-          "prisonIds": {
-            "type": "array",
-            "description": "List of prisons this person attended during this booking",
-            "items": {
-              "type": "string",
-              "description": "List of prisons this person attended during this booking"
-            }
-          },
           "adaSummaries": {
             "type": "array",
             "description": "List of ADAs awarded during this booking period",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationServiceTest.kt
@@ -62,7 +62,6 @@ internal class AdjudicationsReconciliationServiceTest {
           adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
             bookingId = 123456,
             offenderNo = "A1234AA",
-            prisonIds = listOf("MDI"),
             adaSummaries = emptyList(),
           ),
         )
@@ -91,7 +90,6 @@ internal class AdjudicationsReconciliationServiceTest {
           adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
             bookingId = 123456,
             offenderNo = "A1234AA",
-            prisonIds = listOf("MDI"),
             adaSummaries = listOf(nomisSummary(days = 10)),
           ),
         )
@@ -127,7 +125,6 @@ internal class AdjudicationsReconciliationServiceTest {
           adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
             bookingId = 123456,
             offenderNo = "A1234AA",
-            prisonIds = listOf("MDI"),
             adaSummaries = listOf(nomisSummary(days = 10), nomisSummary(days = 3), nomisSummary(days = 9)),
           ),
         )
@@ -163,7 +160,6 @@ internal class AdjudicationsReconciliationServiceTest {
           adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
             bookingId = 123456,
             offenderNo = "A1234AA",
-            prisonIds = listOf("MDI"),
             adaSummaries = listOf(
               nomisSummary(days = 10, effectiveDate = LocalDate.now().minusWeeks(1)),
               nomisSummary(days = 3, effectiveDate = LocalDate.now().minusWeeks(3)),
@@ -196,7 +192,6 @@ internal class AdjudicationsReconciliationServiceTest {
           adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
             bookingId = 123456,
             offenderNo = "A1234AA",
-            prisonIds = listOf("MDI"),
             adaSummaries = listOf(nomisSummary(days = 10)),
           ),
         )
@@ -228,7 +223,6 @@ internal class AdjudicationsReconciliationServiceTest {
           adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
             bookingId = 123456,
             offenderNo = "A1234AA",
-            prisonIds = listOf("MDI"),
             adaSummaries = listOf(nomisSummary(days = 10).copy(sanctionStatus = CodeDescription("QUASHED", "Quashed"))),
           ),
         )
@@ -257,7 +251,6 @@ internal class AdjudicationsReconciliationServiceTest {
           adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
             bookingId = 123456,
             offenderNo = "A1234AA",
-            prisonIds = listOf("MDI"),
             adaSummaries = listOf(nomisSummary(days = 12)),
           ),
         )
@@ -290,14 +283,13 @@ internal class AdjudicationsReconciliationServiceTest {
       adjudicationsApiServer.stubGetAdjudicationsByBookingId(2, listOf(aDPSAdjudication().copy(punishments = listOf(adaPunishment(days = 10)))))
       nomisApi.stubGetAdaAwardSummary(
         bookingId = 1,
-        adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(bookingId = 1, offenderNo = "A1234AA", prisonIds = listOf("MDI"), adaSummaries = emptyList()),
+        adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(bookingId = 1, offenderNo = "A1234AA", adaSummaries = emptyList()),
       )
       nomisApi.stubGetAdaAwardSummary(
         bookingId = 2,
         adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
           bookingId = 2,
           offenderNo = "A1234AA",
-          prisonIds = listOf("MDI"),
           adaSummaries = listOf(nomisSummary(days = 12)),
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsResourceIntTest.kt
@@ -48,7 +48,6 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
         adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
           bookingId = 1,
           offenderNo = "A0001TZ",
-          prisonIds = listOf("MDI"),
           adaSummaries = listOf(nomisSummary(days = 12)),
         ),
       )
@@ -58,7 +57,6 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
         adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
           bookingId = 34,
           offenderNo = "A0034TZ",
-          prisonIds = listOf("MDI"),
           adaSummaries = listOf(nomisSummary(days = 12)),
         ),
       )
@@ -71,7 +69,6 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
           adjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
             bookingId = it,
             offenderNo = "A${it.toString().padStart(4, '0')}TZ",
-            prisonIds = listOf("MDI"),
             adaSummaries = listOf(nomisSummary(days = 10)),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
@@ -1501,7 +1501,6 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
     adjudicationADAAwardSummaryResponse: AdjudicationADAAwardSummaryResponse = AdjudicationADAAwardSummaryResponse(
       bookingId = bookingId,
       offenderNo = "A1234XT",
-      prisonIds = listOf("MDI"),
       adaSummaries = emptyList(),
     ),
   ) {


### PR DESCRIPTION
DPS Reconciliation API no longer needs a list of prisons to retrieve all adductions for a booking