### PR TITLE
SDIT-1534 Send sentence seq when updating sentence adjustment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsService.kt
@@ -116,6 +116,7 @@ class SentencingAdjustmentsService(
       adjustmentFromDate = adjustment.adjustmentFromDate,
       adjustmentDays = adjustment.adjustmentDays.toLong(),
       comment = adjustment.comment,
+      sentenceSequence = adjustment.sentenceSequence,
     ).run {
       if (adjustment.sentenceSequence == null) {
         nomisApiService.updateKeyDateAdjustment(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
@@ -802,6 +802,7 @@ data class UpdateSentencingAdjustmentRequest(
   @JsonFormat(pattern = "yyyy-MM-dd")
   val adjustmentFromDate: LocalDate?,
   val adjustmentDays: Long,
+  val sentenceSequence: Int?,
   val comment: String?,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsToNomisIntTest.kt
@@ -819,6 +819,7 @@ class SentencingAdjustmentsToNomisTest : SqsIntegrationTestBase() {
                 .withRequestBody(matchingJsonPath("adjustmentDate", equalTo("2022-01-01")))
                 .withRequestBody(matchingJsonPath("adjustmentDays", equalTo("99")))
                 .withRequestBody(matchingJsonPath("adjustmentFromDate", equalTo("2020-07-19")))
+                .withRequestBody(matchingJsonPath("sentenceSequence", equalTo("$sentenceSequence")))
                 .withRequestBody(matchingJsonPath("comment", equalTo("Adjusted for remand"))),
             )
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiServiceTest.kt
@@ -2,6 +2,7 @@
 
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.services
 
+import com.github.tomakehurst.wiremock.client.WireMock.absent
 import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
@@ -890,6 +891,7 @@ internal class NomisApiServiceTest {
           adjustmentDays = 9,
           adjustmentFromDate = LocalDate.parse("2020-07-19"),
           comment = "Adjusted for remand",
+          sentenceSequence = 3,
         ),
       )
 
@@ -899,6 +901,7 @@ internal class NomisApiServiceTest {
           .withRequestBody(matchingJsonPath("adjustmentDate", equalTo("2022-01-01")))
           .withRequestBody(matchingJsonPath("adjustmentDays", equalTo("9")))
           .withRequestBody(matchingJsonPath("adjustmentFromDate", equalTo("2020-07-19")))
+          .withRequestBody(matchingJsonPath("sentenceSequence", equalTo("3")))
           .withRequestBody(matchingJsonPath("comment", equalTo("Adjusted for remand"))),
       )
     }
@@ -1076,6 +1079,7 @@ internal class NomisApiServiceTest {
           .withRequestBody(matchingJsonPath("adjustmentDate", equalTo("2022-01-01")))
           .withRequestBody(matchingJsonPath("adjustmentDays", equalTo("9")))
           .withRequestBody(matchingJsonPath("adjustmentFromDate", equalTo("2020-07-19")))
+          .withRequestBody(matchingJsonPath("sentenceSequence", absent()))
           .withRequestBody(matchingJsonPath("comment", equalTo("Adjusted for remand"))),
       )
     }
@@ -1805,12 +1809,14 @@ private fun updateSentencingAdjustment(
   adjustmentFromDate: LocalDate? = null,
   adjustmentDays: Long = 99,
   comment: String? = "Adjustment comment",
+  sentenceSequence: Int? = null,
 ) = UpdateSentencingAdjustmentRequest(
   adjustmentTypeCode = adjustmentTypeCode,
   adjustmentDate = adjustmentDate,
   adjustmentFromDate = adjustmentFromDate,
   adjustmentDays = adjustmentDays,
   comment = comment,
+  sentenceSequence = sentenceSequence,
 )
 
 private fun newAdjudication() = CreateAdjudicationRequest(


### PR DESCRIPTION
DPS can change the sentence related to a sentence adjustment, therefore send this to NOMIS API so it can update it