### PR TITLE
SAA-1592: Sync new attendance reason code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AttendanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AttendanceService.kt
@@ -111,7 +111,7 @@ fun AttendanceSync.toEventOutcome() = attendanceReasonCode?.let {
 
     it == "CANCELLED" -> EventOutcome("CANC", unexcusedAbsence = false, authorisedAbsence = true)
 
-    it == "SUSPENDED" -> EventOutcome("SUS", unexcusedAbsence = false, authorisedAbsence = true)
+    it == "SUSPENDED" || it == "AUTO_SUSPENDED" -> EventOutcome("SUS", unexcusedAbsence = false, authorisedAbsence = true)
 
     it == "SICK" && issuePayment == true -> EventOutcome("ACCAB", unexcusedAbsence = false, authorisedAbsence = true)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AttendanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AttendanceServiceTest.kt
@@ -353,6 +353,7 @@ class AttendanceServiceTest {
         "ATTENDED,false,UNBEH,false,false",
         "CANCELLED,true,CANC,false,true",
         "SUSPENDED,false,SUS,false,true",
+        "AUTO_SUSPENDED,false,SUS,false,true",
         "SICK,true,ACCAB,false,true",
         "SICK,false,REST,false,true",
         "REFUSED,false,UNACAB,true,false",


### PR DESCRIPTION
The activities team are adding a new attendance reason code to distinguish between:

SUSPENDED -> (The prison have chosen to suspend the prisoner from the activity due to poor behaviour for example)
AUTO_SUSPENDED -> (The prisoner has been automatically suspended from the activity due to temporary release from the prison)

This change is to sync the new attendance reason, which is to behave exactly same as SUSPENDED for sync