### PR TITLE
SDIT-1597 Handle `prisoner-alerts.alert-deleted` domain event

### DIFF
--- a/openapi-specs/nomis-sync-api-docs.json
+++ b/openapi-specs/nomis-sync-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2024-03-14.6978.f56c655"
+    "version": "2024-03-19.7028.8fb823c"
   },
   "servers": [
     {
@@ -734,6 +734,65 @@
           },
           "404": {
             "description": "Alert does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "alerts-resource"
+        ],
+        "summary": "Deletes an alert by bookingId and alert sequence",
+        "description": "Deletes an prisoner alert. Requires ROLE_NOMIS_ALERTS",
+        "operationId": "deleteAlert",
+        "parameters": [
+          {
+            "name": "bookingId",
+            "in": "path",
+            "description": "Booking Id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Booking Id",
+              "example": 12345
+            },
+            "example": 12345
+          },
+          {
+            "name": "alertSequence",
+            "in": "path",
+            "description": "Alert sequence",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Alert sequence",
+              "example": 3
+            },
+            "example": 3
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Alert Deleted"
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint. Requires ROLE_NOMIS_ALERTS",
             "content": {
               "application/json": {
                 "schema": {
@@ -6027,6 +6086,16 @@
               "example": 12345
             },
             "example": 12345
+          },
+          {
+            "name": "active-only",
+            "in": "query",
+            "description": "Indicate if should return just active adjustments",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Indicate if should return just active adjustments"
+            }
           }
         ],
         "responses": {
@@ -8658,7 +8727,6 @@
       },
       "UpdateSentenceAdjustmentRequest": {
         "required": [
-          "active",
           "adjustmentDays",
           "adjustmentTypeCode",
           "sentenceSequence"
@@ -8713,13 +8781,10 @@
       },
       "UpsertAttendanceRequest": {
         "required": [
-          "authorisedAbsence",
           "endTime",
           "eventStatusCode",
-          "paid",
           "scheduleDate",
-          "startTime",
-          "unexcusedAbsence"
+          "startTime"
         ],
         "type": "object",
         "properties": {
@@ -9270,7 +9335,8 @@
               "HOU_SANI_FIT",
               "HOU_UNIT_ATT",
               "HOU_USED_FOR",
-              "SUP_LVL_TYPE"
+              "SUP_LVL_TYPE",
+              "NON_ASSO_TYP"
             ]
           },
           "profileCode": {
@@ -9415,6 +9481,7 @@
               "OCCUR",
               "OIC",
               "OTHER",
+              "OTH",
               "PROG",
               "PROP",
               "VISIT"
@@ -9552,7 +9619,6 @@
       },
       "UpdateKeyDateAdjustmentRequest": {
         "required": [
-          "active",
           "adjustmentDays",
           "adjustmentFromDate",
           "adjustmentTypeCode"
@@ -11744,7 +11810,6 @@
       },
       "CreateSentenceAdjustmentRequest": {
         "required": [
-          "active",
           "adjustmentDays",
           "adjustmentTypeCode"
         ],
@@ -11824,7 +11889,6 @@
       },
       "CreateKeyDateAdjustmentRequest": {
         "required": [
-          "active",
           "adjustmentDays",
           "adjustmentFromDate",
           "adjustmentTypeCode"
@@ -11944,7 +12008,6 @@
       },
       "CreateLocationRequest": {
         "required": [
-          "certified",
           "description",
           "locationCode",
           "locationType",
@@ -12637,7 +12700,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -12659,18 +12725,21 @@
             "format": "int64"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "pageSize": {
             "type": "integer",
             "format": "int32"
           },
+          "paged": {
+            "type": "boolean"
+          },
           "pageNumber": {
             "type": "integer",
             "format": "int32"
-          },
-          "paged": {
-            "type": "boolean"
           },
           "unpaged": {
             "type": "boolean"
@@ -12680,13 +12749,19 @@
       "SortObject": {
         "type": "object",
         "properties": {
-          "empty": {
+          "direction": {
+            "type": "string"
+          },
+          "nullHandling": {
+            "type": "string"
+          },
+          "ascending": {
             "type": "boolean"
           },
-          "sorted": {
-            "type": "boolean"
+          "property": {
+            "type": "string"
           },
-          "unsorted": {
+          "ignoreCase": {
             "type": "boolean"
           }
         }
@@ -13070,7 +13145,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -13567,7 +13645,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -14130,7 +14211,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -14147,7 +14231,6 @@
       "LocationResponse": {
         "required": [
           "active",
-          "certified",
           "createDatetime",
           "createUsername",
           "description",
@@ -14340,7 +14423,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -14793,7 +14879,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -14859,7 +14948,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -15133,7 +15225,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -15459,7 +15554,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -15524,7 +15622,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -15595,7 +15696,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -15900,7 +16004,10 @@
             "format": "int32"
           },
           "sort": {
-            "$ref": "#/components/schemas/SortObject"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
           },
           "numberOfElements": {
             "type": "integer",
@@ -15950,6 +16057,8 @@
     "securitySchemes": {
       "bearer-jwt": {
         "type": "http",
+        "name": "Authorization",
+        "in": "header",
         "scheme": "bearer",
         "bearerFormat": "JWT"
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiService.kt
@@ -24,4 +24,14 @@ class AlertsMappingApiService(@Qualifier("mappingWebClient") private val webClie
       .retrieve()
       .awaitBodilessEntity()
   }
+
+  suspend fun deleteByDpsId(alertId: String) {
+    webClient.delete()
+      .uri(
+        "/mapping/alerts/dps-alert-id/{alertId}",
+        alertId,
+      )
+      .retrieve()
+      .awaitBodilessEntity()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonertonomisupdate.alerts
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import org.springframework.web.reactive.function.client.awaitBody
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AlertResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.CreateAlertRequest
@@ -28,4 +29,14 @@ class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClien
     .bodyValue(nomisAlert)
     .retrieve()
     .awaitBody()
+
+  suspend fun deleteAlert(bookingId: Long, alertSequence: Long) {
+    webClient.delete().uri(
+      "/prisoners/booking-id/{bookingId}/alerts/{alertSequence}",
+      bookingId,
+      alertSequence,
+    )
+      .retrieve()
+      .awaitBodilessEntity()
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiMockServer.kt
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.delete
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import org.springframework.http.HttpStatus
@@ -92,6 +94,29 @@ class AlertsMappingApiMockServer(private val objectMapper: ObjectMapper) {
             .withStatus(201),
 
         ).willSetStateTo(Scenario.STARTED),
+    )
+  }
+
+  fun stubDeleteByDpsId(status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
+    mappingServer.stubFor(
+      delete(urlMatching("/mapping/alerts/dps-alert-id/.*")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(status.value())
+          .withBody(objectMapper.writeValueAsString(error)),
+      ),
+    )
+  }
+
+  fun stubDeleteByDpsId(
+    dpsAlertId: String = UUID.randomUUID().toString(),
+  ) {
+    mappingServer.stubFor(
+      delete(urlEqualTo("/mapping/alerts/dps-alert-id/$dpsAlertId")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.NO_CONTENT.value()),
+      ),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.alerts
 
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
@@ -130,6 +131,34 @@ class AlertsMappingApiServiceTest {
           .withRequestBody(matchingJsonPath("nomisAlertSequence", equalTo("1")))
           .withRequestBody(matchingJsonPath("dpsAlertId", equalTo(dpsAlertId)))
           .withRequestBody(matchingJsonPath("mappingType", equalTo("DPS_CREATED"))),
+      )
+    }
+  }
+
+  @Nested
+  inner class DeleteMapping {
+    private val dpsAlertId = UUID.randomUUID().toString()
+
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      alertsMappingApiMockServer.stubDeleteByDpsId(dpsAlertId)
+
+      apiService.deleteByDpsId(dpsAlertId)
+
+      alertsMappingApiMockServer.verify(
+        deleteRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass ids to service`() = runTest {
+      val dpsAlertId = "a04f7a8d-61aa-400c-9395-f4dc62f36ab0"
+      alertsMappingApiMockServer.stubDeleteByDpsId(dpsAlertId)
+
+      apiService.deleteByDpsId(dpsAlertId)
+
+      alertsMappingApiMockServer.verify(
+        deleteRequestedFor(urlPathEqualTo("/mapping/alerts/dps-alert-id/$dpsAlertId")),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiMockServer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonertonomisupdate.alerts
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.delete
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.put
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
@@ -44,6 +45,19 @@ class AlertsNomisApiMockServer(private val objectMapper: ObjectMapper) {
           .withHeader("Content-Type", "application/json")
           .withStatus(HttpStatus.OK.value())
           .withBody(objectMapper.writeValueAsString(alert)),
+      ),
+    )
+  }
+
+  fun stubDeleteAlert(
+    bookingId: Long = 12345678,
+    alertSequence: Long = 3,
+  ) {
+    nomisApi.stubFor(
+      delete(urlEqualTo("/prisoners/booking-id/$bookingId/alerts/$alertSequence")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.NO_CONTENT.value()),
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.alerts
 
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
@@ -130,5 +131,30 @@ class AlertsNomisApiServiceTest {
       isActive = true,
       updateUsername = "BOBBY.BEANS",
     )
+  }
+
+  @Nested
+  inner class DeleteAlert {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      alertsNomisApiMockServer.stubDeleteAlert(bookingId = 1234567, alertSequence = 4)
+
+      apiService.deleteAlert(bookingId = 1234567, alertSequence = 4)
+
+      alertsNomisApiMockServer.verify(
+        deleteRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass alert Id to service`() = runTest {
+      alertsNomisApiMockServer.stubDeleteAlert(bookingId = 1234567, alertSequence = 4)
+
+      apiService.deleteAlert(bookingId = 1234567, alertSequence = 4)
+
+      alertsNomisApiMockServer.verify(
+        deleteRequestedFor(urlPathEqualTo("/prisoners/booking-id/1234567/alerts/4")),
+      )
+    }
   }
 }


### PR DESCRIPTION
Will try to delete if delete originated from DPS and mapping still exists. 
Will pragmatically ignore delete mapping failures