### PR TITLE
Remove unused 'occurredAt' message fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesService.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiServi
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.synchronise
 import java.lang.Integer.min
 import java.math.BigDecimal
-import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Service
@@ -263,7 +262,6 @@ data class ScheduleDomainEvent(
   val additionalInformation: ScheduleAdditionalInformation,
   val version: String,
   val description: String,
-  val occurredAt: LocalDateTime,
 )
 
 data class ScheduleAdditionalInformation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AllocationService.kt
@@ -68,7 +68,7 @@ class AllocationService(
       suspended = isSuspended(allocation.status),
       suspendedComment = getSuspendedComment(allocation.status, allocation.suspendedBy, allocation.suspendedTime, allocation.suspendedReason),
       programStatusCode = getProgramStatus(allocation.status),
-      exclusions = toAllocationExclusions(allocation.exclusions ?: listOf()),
+      exclusions = toAllocationExclusions(allocation.exclusions),
     )
 
   private fun getEndReason(status: Allocation.Status) =
@@ -128,7 +128,6 @@ data class AllocationDomainEvent(
   val eventType: String,
   val version: String,
   val description: String,
-  val occurredAt: LocalDateTime,
   val additionalInformation: AllocationAdditionalInformation,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AttendanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AttendanceService.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiServi
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Service
 class AttendanceService(
@@ -152,7 +151,6 @@ data class AttendanceDomainEvent(
   val additionalInformation: AttendanceAdditionalInformation,
   val version: String,
   val description: String,
-  val occurredAt: LocalDateTime,
 )
 
 data class AttendanceAdditionalInformation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/SchedulesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/SchedulesService.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.model.Activ
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.model.ScheduledInstance
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.CourseScheduleRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
-import java.time.LocalDateTime
 
 @Service
 class SchedulesService(
@@ -77,7 +76,6 @@ data class ScheduledInstanceDomainEvent(
   val additionalInformation: ScheduledInstanceAdditionalInformation,
   val version: String,
   val description: String,
-  val occurredAt: LocalDateTime,
 )
 
 data class ScheduledInstanceAdditionalInformation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.CreateMapping
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.UpdateAppointmentRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.synchronise
-import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Service
@@ -224,7 +223,6 @@ data class AppointmentDomainEvent(
   val eventType: String,
   val version: String,
   val description: String,
-  val occurredAt: LocalDateTime,
   val additionalInformation: AppointmentAdditionalInformation,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesServiceTest.kt
@@ -64,7 +64,6 @@ internal class ActivitiesServiceTest {
         additionalInformation = ScheduleAdditionalInformation(ACTIVITY_SCHEDULE_ID),
         version = "1.0",
         description = "description",
-        occurredAt = LocalDateTime.now(),
       )
 
     @Test
@@ -170,7 +169,6 @@ internal class ActivitiesServiceTest {
         additionalInformation = ScheduleAdditionalInformation(ACTIVITY_SCHEDULE_ID),
         version = "1.0",
         description = "description",
-        occurredAt = LocalDateTime.now(),
       )
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AllocationServiceTest.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.Alloca
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.UpsertAllocationResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 class AllocationServiceTest {
 
@@ -56,7 +55,6 @@ class AllocationServiceTest {
           eventType = "dummy",
           version = "1.0",
           description = "description",
-          occurredAt = LocalDateTime.now(),
           additionalInformation = AllocationAdditionalInformation(
             allocationId = ALLOCATION_ID,
           ),
@@ -96,7 +94,6 @@ class AllocationServiceTest {
               eventType = "dummy",
               version = "1.0",
               description = "description",
-              occurredAt = LocalDateTime.now(),
               additionalInformation = AllocationAdditionalInformation(
                 allocationId = ALLOCATION_ID,
               ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AttendanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/AttendanceServiceTest.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiServi
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 class AttendanceServiceTest {
 
@@ -291,7 +290,6 @@ class AttendanceServiceTest {
       additionalInformation = AttendanceAdditionalInformation(ATTENDANCE_ID),
       version = "1.0",
       description = "some description",
-      occurredAt = LocalDateTime.now(),
     )
 
     private fun attendanceSyncWaiting() = AttendanceSync(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/SchedulesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/SchedulesServiceTest.kt
@@ -45,7 +45,6 @@ class SchedulesServiceTest {
         additionalInformation = ScheduledInstanceAdditionalInformation(ACTIVITY_SCHEDULE_ID, SCHEDULE_INSTANCE_ID),
         version = "1.0",
         description = "description",
-        occurredAt = LocalDateTime.now(),
       )
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/appointments/AppointmentsServiceTest.kt
@@ -117,7 +117,6 @@ internal class AppointmentsServiceTest {
       "TYPE",
       "version",
       "description",
-      LocalDateTime.now(),
       AppointmentAdditionalInformation(appointmentInstanceId = APPOINTMENT_INSTANCE_ID),
     )
     appointmentsService.updateAppointment(appointment)
@@ -144,7 +143,6 @@ internal class AppointmentsServiceTest {
       "TYPE",
       "version",
       "description",
-      LocalDateTime.now(),
       AppointmentAdditionalInformation(appointmentInstanceId = APPOINTMENT_INSTANCE_ID),
     )
     appointmentsService.createAppointment(appointment)


### PR DESCRIPTION
They were declared as the wrong type anyway: the occurredAt field is an OffsetDateTime.