### PR TITLE
SDIT-1625 Ignore Adjudication mismatch for merges

### DIFF
--- a/openapi-specs/nomis-sync-api-docs.json
+++ b/openapi-specs/nomis-sync-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2024-03-21.7051.058dee4"
+    "version": "2024-04-03.7132.310f3d6"
   },
   "servers": [
     {
@@ -5857,6 +5857,76 @@
         }
       }
     },
+    "/prisoners/{offenderNo}/merges": {
+      "get": {
+        "tags": [
+          "prisoners-resource"
+        ],
+        "summary": "Gets prisoner's list of merge details since a given date",
+        "description": "Requires role SYNCHRONISATION_REPORTING.",
+        "operationId": "getPrisonerMerges",
+        "parameters": [
+          {
+            "name": "offenderNo",
+            "in": "path",
+            "description": "Offender Noms Id",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z]\\d{4}[A-Z]{2}",
+              "type": "string",
+              "description": "Offender Noms Id",
+              "example": "A1234ZZ"
+            },
+            "example": "A1234ZZ"
+          },
+          {
+            "name": "fromDate",
+            "in": "query",
+            "description": "The earliest date to search for merges from",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "list of prisoner merges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MergeDetail"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint when role SYNCHRONISATION_REPORTING not present",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/prisoners/ids": {
       "get": {
         "tags": [
@@ -7918,6 +7988,80 @@
         }
       }
     },
+    "/alerts/ids": {
+      "get": {
+        "tags": [
+          "alerts-resource"
+        ],
+        "summary": "Get alert IDs by filter",
+        "description": "Retrieves a paged list of alert ids by filter. Requires ROLE_NOMIS_ALERTS.",
+        "operationId": "getAlertIdsByFilter",
+        "parameters": [
+          {
+            "name": "pageRequest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Pageable"
+            }
+          },
+          {
+            "name": "fromDate",
+            "in": "query",
+            "description": "Filter results by alerts that were created on or after the given date",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "example": "2021-11-03"
+          },
+          {
+            "name": "toDate",
+            "in": "query",
+            "description": "Filter results by alerts that were created on or before the given date",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "example": "2021-11-03"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pageable list of ids are returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageAlertIdResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint when role ROLE_NOMIS_ALERTS not present",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/adjustments/ids": {
       "get": {
         "tags": [
@@ -9189,9 +9333,17 @@
             "type": "string",
             "description": "Username of person that created the record (might also be a system) "
           },
+          "createDisplayName": {
+            "type": "string",
+            "description": "Real name of person that created the record (might by null for system users)"
+          },
           "modifyUserId": {
             "type": "string",
             "description": "Username of person that last modified the record (might also be a system)"
+          },
+          "modifyDisplayName": {
+            "type": "string",
+            "description": "Real name of person that modified the record (might by null for system users)"
           },
           "modifyDatetime": {
             "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
@@ -13613,6 +13765,47 @@
         },
         "description": "Sentence Purpose"
       },
+      "MergeDetail": {
+        "required": [
+          "activeBookingId",
+          "deletedOffenderNo",
+          "previousBookingId",
+          "requestDateTime",
+          "retainedOffenderNo"
+        ],
+        "type": "object",
+        "properties": {
+          "deletedOffenderNo": {
+            "type": "string",
+            "description": "The NOMIS reference of the record that was merged to and was then removed",
+            "example": "A1234AA"
+          },
+          "activeBookingId": {
+            "type": "integer",
+            "description": "The booking that was merged to and which then became active",
+            "format": "int64",
+            "example": 12345678
+          },
+          "retainedOffenderNo": {
+            "type": "string",
+            "description": "The NOMIS reference of the record that was merged from and was retained",
+            "example": "A1234AA"
+          },
+          "previousBookingId": {
+            "type": "integer",
+            "description": "The booking that was merged from and was retained as inactive",
+            "format": "int64",
+            "example": 12345678
+          },
+          "requestDateTime": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+            "type": "string",
+            "description": "When the merge happened",
+            "example": "2021-07-05T10:35:17"
+          }
+        },
+        "description": "Details of a prisoner merge"
+      },
       "PagePrisonerId": {
         "type": "object",
         "properties": {
@@ -15593,6 +15786,80 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FindActiveAllocationIdsResponse"
+            }
+          },
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
+          },
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      },
+      "AlertIdResponse": {
+        "required": [
+          "alertSequence",
+          "bookingId",
+          "offenderNo"
+        ],
+        "type": "object",
+        "properties": {
+          "bookingId": {
+            "type": "integer",
+            "description": "The booking id",
+            "format": "int64"
+          },
+          "alertSequence": {
+            "type": "integer",
+            "description": "The alert sequence",
+            "format": "int64"
+          },
+          "offenderNo": {
+            "type": "string",
+            "description": "The prisoner number"
+          }
+        },
+        "description": "Alert id"
+      },
+      "PageAlertIdResponse": {
+        "type": "object",
+        "properties": {
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertIdResponse"
             }
           },
           "number": {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationService.kt
@@ -96,7 +96,7 @@ class AdjudicationsReconciliationService(
   private suspend fun mismatchNotDueToAMerge(prisonerId: ActivePrisonerId, nomisSummary: AdjudicationADAAwardSummaryResponse, dpsAdjudications: List<ReportedAdjudicationDto>): Boolean {
     val merges = nomisApiService.mergesSinceDate(prisonerId.offenderNo, nomisMigrationDate)
     if (merges.isNotEmpty()) {
-      log.debug("Merges found for {} the latest on {}", prisonerId.offenderNo, merges.last().dateTime)
+      log.debug("Merges found for {} the latest on {}", prisonerId.offenderNo, merges.last().requestDateTime)
       val adjudicationsNotPresentOnDPSBooking = adjudicationsNotPresentOnDPSBooking(nomisSummary, dpsAdjudications)
       log.debug("Missing adjudications on DPS booking {}", adjudicationsNotPresentOnDPSBooking)
       if (adjudicationsNotPresentOnDPSBooking.isNotEmpty()) {
@@ -111,8 +111,8 @@ class AdjudicationsReconciliationService(
             "dpsAdaCount" to (dpsAdaSummary.count.toString()),
             "nomisAdaDays" to (nomisAdaSummary.days.toString()),
             "dpsAdaDays" to (dpsAdaSummary.days.toString()),
-            "mergeDate" to (merges.last().dateTime.toString()),
-            "mergeFrom" to (merges.last().fromOffenderNo),
+            "mergeDate" to (merges.last().requestDateTime),
+            "mergeFrom" to (merges.last().deletedOffenderNo),
             "missingAdjudications" to (adjudicationsNotPresentOnDPSBooking.joinToString()),
           ),
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationService.kt
@@ -17,14 +17,18 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.ActivePrisone
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.asPages
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.doApiCallWithRetries
+import java.time.LocalDate
 
 @Service
 class AdjudicationsReconciliationService(
   private val telemetryClient: TelemetryClient,
   private val nomisApiService: NomisApiService,
   private val adjudicationsApiService: AdjudicationsApiService,
+  private val adjudicationsMappingService: AdjudicationsMappingService,
   @Value("\${reports.sentencing.reconciliation.page-size}")
   private val pageSize: Long = 20,
+  @Value("\${reports.sentencing.reconciliation.migration-date}")
+  private val nomisMigrationDate: LocalDate,
 ) {
   private companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -60,7 +64,7 @@ class AdjudicationsReconciliationService(
 
     val nomisAdaSummary: AdaSummary = nomisSummary.toAdaSummary()
     val dpsAdaSummary: AdaSummary = dpsAdjudications.toAdaSummary()
-    return if (nomisAdaSummary != dpsAdaSummary) {
+    return if (nomisAdaSummary != dpsAdaSummary && mismatchNotDueToAMerge(prisonerId, nomisSummary, dpsAdjudications)) {
       MismatchAdjudicationAdaPunishments(prisonerId = prisonerId, dpsAdas = dpsAdaSummary, nomisAda = nomisAdaSummary).also { mismatch ->
         log.info("Adjudications Mismatch found  $mismatch")
         telemetryClient.trackEvent(
@@ -88,6 +92,43 @@ class AdjudicationsReconciliationService(
       ),
     )
   }.getOrNull()
+
+  private suspend fun mismatchNotDueToAMerge(prisonerId: ActivePrisonerId, nomisSummary: AdjudicationADAAwardSummaryResponse, dpsAdjudications: List<ReportedAdjudicationDto>): Boolean {
+    val merges = nomisApiService.mergesSinceDate(prisonerId.offenderNo, nomisMigrationDate)
+    if (merges.isNotEmpty()) {
+      log.debug("Merges found for {} the latest on {}", prisonerId.offenderNo, merges.last().dateTime)
+      val adjudicationsNotPresentOnDPSBooking = adjudicationsNotPresentOnDPSBooking(nomisSummary, dpsAdjudications)
+      log.debug("Missing adjudications on DPS booking {}", adjudicationsNotPresentOnDPSBooking)
+      if (adjudicationsNotPresentOnDPSBooking.isNotEmpty()) {
+        val nomisAdaSummary = nomisSummary.toAdaSummary()
+        val dpsAdaSummary = dpsAdjudications.toAdaSummary()
+        telemetryClient.trackEvent(
+          "adjudication-reports-reconciliation-merge-mismatch",
+          mapOf(
+            "offenderNo" to prisonerId.offenderNo,
+            "bookingId" to prisonerId.bookingId.toString(),
+            "nomisAdaCount" to (nomisAdaSummary.count.toString()),
+            "dpsAdaCount" to (dpsAdaSummary.count.toString()),
+            "nomisAdaDays" to (nomisAdaSummary.days.toString()),
+            "dpsAdaDays" to (dpsAdaSummary.days.toString()),
+            "mergeDate" to (merges.last().dateTime.toString()),
+            "mergeFrom" to (merges.last().fromOffenderNo),
+            "missingAdjudications" to (adjudicationsNotPresentOnDPSBooking.joinToString()),
+          ),
+        )
+        return false
+      } else {
+        return true
+      }
+    } else {
+      return true
+    }
+  }
+
+  private suspend fun adjudicationsNotPresentOnDPSBooking(nomisSummary: AdjudicationADAAwardSummaryResponse, dpsAdjudications: List<ReportedAdjudicationDto>): List<Long> {
+    val dpsAdjudicationNumbers = dpsAdjudications.mapNotNull { adjudicationsMappingService.getMappingGivenChargeNumberOrNull(it.chargeNumber)?.adjudicationNumber }
+    return nomisSummary.adaSummaries.filter { it.adjudicationNumber !in dpsAdjudicationNumbers }.map { it.adjudicationNumber }
+  }
 }
 
 private val dpsAdaTypes = listOf(PunishmentDto.Type.ADDITIONAL_DAYS, PunishmentDto.Type.PROSPECTIVE_DAYS)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
@@ -45,6 +45,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.Delete
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.Hearing
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.LocationIdResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.LocationResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.MergeDetail
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.NonAssociationIdResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.NonAssociationResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.PrisonDetails
@@ -729,13 +730,6 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
       .awaitBody()
 }
 
-data class MergeDetail(
-  val fromOffenderNo: String,
-  val fromBookingId: Long,
-  val toOffenderNo: String,
-  val toBookingId: Long,
-  val dateTime: LocalDateTime,
-)
 data class CreateVisitDto(
   val offenderNo: String,
   val prisonId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
@@ -721,8 +721,21 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
       .bodyValue(request)
       .retrieve()
       .awaitBody()
+
+  suspend fun mergesSinceDate(offenderNo: String, fromDate: LocalDate): List<MergeDetail> =
+    webClient.get()
+      .uri("/prisoners/{offenderNo}/merges?fromDate={fromDate}", offenderNo, fromDate)
+      .retrieve()
+      .awaitBody()
 }
 
+data class MergeDetail(
+  val fromOffenderNo: String,
+  val fromBookingId: Long,
+  val toOffenderNo: String,
+  val toBookingId: Long,
+  val dateTime: LocalDateTime,
+)
 data class CreateVisitDto(
   val offenderNo: String,
   val prisonId: String,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -130,6 +130,7 @@ reports:
       page-size: 20
   sentencing:
     reconciliation:
+      migration-date: 2024-01-28
       page-size: 20
   non-associations:
     reconciliation:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsReconciliationServiceTest.kt
@@ -33,14 +33,13 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.SpringAPIServi
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.ADASummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AdjudicationADAAwardSummaryResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.CodeDescription
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.MergeDetail
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.ActivePrisonerId
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.MergeDetail
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.AdjudicationsApiExtension.Companion.adjudicationsApiServer
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.MappingExtension.Companion.mappingServer
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.NomisApiExtension.Companion.nomisApi
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @SpringAPIServiceTest
 @Import(
@@ -305,7 +304,7 @@ internal class AdjudicationsReconciliationServiceTest {
           nomisApi.stubGetMergesFromDate(
             offenderNo = "A1234AA",
             merges = listOf(
-              MergeDetail(fromOffenderNo = "A1234AB", toOffenderNo = "A1234AA", fromBookingId = 1234, toBookingId = 1235, dateTime = LocalDateTime.parse("2024-02-02T12:34:56")),
+              MergeDetail(deletedOffenderNo = "A1234AB", retainedOffenderNo = "A1234AA", previousBookingId = 1234, activeBookingId = 1235, requestDateTime = "2024-02-02T12:34:56"),
             ),
           )
           mappingServer.stubGetByChargeNumber("MDI-00010", 10234567)
@@ -379,7 +378,7 @@ internal class AdjudicationsReconciliationServiceTest {
           nomisApi.stubGetMergesFromDate(
             offenderNo = "A1234AA",
             merges = listOf(
-              MergeDetail(fromOffenderNo = "A1234AB", toOffenderNo = "A1234AA", fromBookingId = 1234, toBookingId = 1235, dateTime = LocalDateTime.parse("2024-02-02T12:34:56")),
+              MergeDetail(deletedOffenderNo = "A1234AB", retainedOffenderNo = "A1234AA", previousBookingId = 1234, activeBookingId = 1235, requestDateTime = "2024-02-02T12:34:56"),
             ),
           )
           mappingServer.stubGetByChargeNumber("MDI-00001", 1000001)
@@ -467,7 +466,7 @@ internal class AdjudicationsReconciliationServiceTest {
           nomisApi.stubGetMergesFromDate(
             offenderNo = "A1234AA",
             merges = listOf(
-              MergeDetail(fromOffenderNo = "A1234AB", toOffenderNo = "A1234AA", fromBookingId = 1234, toBookingId = 1235, dateTime = LocalDateTime.parse("2024-02-02T12:34:56")),
+              MergeDetail(deletedOffenderNo = "A1234AB", retainedOffenderNo = "A1234AA", previousBookingId = 1234, activeBookingId = 1235, requestDateTime = "2024-02-02T12:34:56"),
             ),
           )
           mappingServer.stubGetByChargeNumber("MDI-00001", 1000001)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsResourceIntTest.kt
@@ -73,6 +73,9 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
           ),
         )
       }
+
+      nomisApi.stubGetMergesFromDate("A0001TZ")
+      nomisApi.stubGetMergesFromDate("A0034TZ")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiServiceTest.kt
@@ -35,6 +35,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.Eviden
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.ExistingHearingResultAwardRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.HearingResultAwardRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.IncidentToCreate
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.MergeDetail
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.RepairToUpdateOrAdd
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.UnquashHearingResultAwardRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.UpdateActivityRequest
@@ -1682,15 +1683,15 @@ internal class NomisApiServiceTest {
       nomisApi.stubGetMergesFromDate(
         offenderNo = "A1234AA",
         merges = listOf(
-          MergeDetail(fromOffenderNo = "A1234AB", toOffenderNo = "A1234AA", fromBookingId = 1234, toBookingId = 1235, dateTime = LocalDateTime.parse("2024-02-02T12:34:56")),
-          MergeDetail(fromOffenderNo = "A1234AC", toOffenderNo = "A1234AA", fromBookingId = 1233, toBookingId = 1234, dateTime = LocalDateTime.parse("2024-02-01T13:34:56")),
+          MergeDetail(deletedOffenderNo = "A1234AB", retainedOffenderNo = "A1234AA", previousBookingId = 1234, activeBookingId = 1235, requestDateTime = "2024-02-02T12:34:56"),
+          MergeDetail(deletedOffenderNo = "A1234AC", retainedOffenderNo = "A1234AA", previousBookingId = 1233, activeBookingId = 1234, requestDateTime = "2024-02-01T13:34:56"),
         ),
       )
 
       val merges = nomisApiService.mergesSinceDate(offenderNo = "A1234AA", fromDate = LocalDate.parse("2022-01-01"))
       assertThat(merges).hasSize(2)
-      assertThat(merges.first().dateTime).isEqualTo(LocalDateTime.parse("2024-02-02T12:34:56"))
-      assertThat(merges.last().dateTime).isEqualTo(LocalDateTime.parse("2024-02-01T13:34:56"))
+      assertThat(merges.first().requestDateTime).isEqualTo("2024-02-02T12:34:56")
+      assertThat(merges.last().requestDateTime).isEqualTo("2024-02-01T13:34:56")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AdjudicationADAAwardSummaryResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.MergeDetail
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.SentencingAdjustmentsResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.ActivePrisonerId
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.MergeDetail
 import java.time.LocalDate
 
 class NomisApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
@@ -22,6 +22,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AdjudicationADAAwardSummaryResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.SentencingAdjustmentsResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.ActivePrisonerId
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.MergeDetail
 import java.time.LocalDate
 
 class NomisApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
@@ -1528,6 +1529,23 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
             .withHeader("Content-Type", "application/json")
             .withStatus(status)
             .withBody("""{"message":"Error"}"""),
+        ),
+    )
+  }
+
+  fun stubGetMergesFromDate(
+    offenderNo: String,
+    merges: List<MergeDetail> = emptyList(),
+  ) {
+    stubFor(
+      get(
+        urlPathEqualTo("/prisoners/$offenderNo/merges"),
+      )
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(HttpStatus.OK.value())
+            .withBody(merges),
         ),
     )
   }


### PR DESCRIPTION


If there is an ADA mismatch and there has been a merge since migration and there is an adjudication missing on the active DPS booking then ignore mismatch.

TODO - can make more sophisticated by finding the missing adjudication and find the actual number of ADA days