### PR TITLE
SDIT-1762 Use Adjudication duration rather than days

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.Ou
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.OutcomeHistoryDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.PunishmentDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.PunishmentDto.Type
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.PunishmentScheduleDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.ReportedAdjudicationDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.ReportedAdjudicationResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.adjudications.model.ReportedDamageDto
@@ -962,7 +963,7 @@ class AdjudicationsService(
     sanctionType = this.type.toNomisSanctionType(),
     sanctionStatus = this.toNomisSanctionStatus(),
     effectiveDate = this.schedule.startDate ?: this.schedule.suspendedUntil ?: LocalDate.now(),
-    sanctionDays = this.schedule.days,
+    sanctionDays = this.schedule.takeIf { it.measurement == PunishmentScheduleDto.Measurement.DAYS }?.duration ?: 0,
     compensationAmount = this.damagesOwedAmount?.toBigDecimal() ?: stoppagePercentage?.toBigDecimal(),
     commentText = this.toComment(),
     consecutiveCharge = this.consecutiveChargeNumber?.let { chargeNumber ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsDataRepairResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsDataRepairResourceIntTest.kt
@@ -79,6 +79,7 @@ class AdjudicationsDataRepairResourceIntTest : IntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 3,
+                    "duration": 3,
                     "startDate": "2023-10-04",
                     "endDate": "2023-10-06",
                     "measurement": "DAYS"
@@ -90,6 +91,7 @@ class AdjudicationsDataRepairResourceIntTest : IntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 12,
+                    "duration": 12,
                     "suspendedUntil": "2023-10-18",
                     "measurement": "DAYS"
                 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/PunishmentsToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/PunishmentsToNomisIntTest.kt
@@ -64,6 +64,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 3,
+                    "duration": 3,
                     "startDate": "2023-10-04",
                     "endDate": "2023-10-06",
                     "measurement": "DAYS"
@@ -75,8 +76,20 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 12,
+                    "duration": 12,
                     "suspendedUntil": "2023-10-18",
                     "measurement": "DAYS"
+                }
+            },
+            {
+                "id": 668,
+                "type": "PAYBACK",
+                "rehabilitativeActivities": [],
+                "schedule": {
+                    "days": 12,
+                    "duration": 12,
+                    "suspendedUntil": "2023-10-18",
+                    "measurement": "HOURS"
                 }
             }
         ]
@@ -86,7 +99,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
         nomisApi.stubAdjudicationAwardsCreate(
           ADJUDICATION_NUMBER,
           CHARGE_SEQ,
-          awardIds = listOf(12345L to 10, 12345L to 11),
+          awardIds = listOf(12345L to 10, 12345L to 11, 12345L to 12),
         )
         mappingServer.stubCreatePunishments()
         publishCreatePunishmentsDomainEvent()
@@ -111,7 +124,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
             assertThat(it["prisonId"]).isEqualTo(PRISON_ID)
             assertThat(it["adjudicationNumber"]).isEqualTo(ADJUDICATION_NUMBER.toString())
             assertThat(it["chargeSequence"]).isEqualTo(CHARGE_SEQ.toString())
-            assertThat(it["punishmentsCount"]).isEqualTo("2")
+            assertThat(it["punishmentsCount"]).isEqualTo("3")
           },
           isNull(),
         )
@@ -125,7 +138,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
       }
 
       @Test
-      fun `will map DPS punishments to NOMIS awards`() {
+      fun `will map DPS punishments to NOMIS awards ignoring sanction lengths in hours`() {
         waitForCreatePunishmentProcessingToBeComplete()
 
         nomisApi.verify(
@@ -137,7 +150,11 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
             .withRequestBody(matchingJsonPath("awards[1].sanctionType", equalTo("EXTW")))
             .withRequestBody(matchingJsonPath("awards[1].sanctionStatus", equalTo("SUSPENDED")))
             .withRequestBody(matchingJsonPath("awards[1].effectiveDate", equalTo("2023-10-18")))
-            .withRequestBody(matchingJsonPath("awards[1].sanctionDays", equalTo("12"))),
+            .withRequestBody(matchingJsonPath("awards[1].sanctionDays", equalTo("12")))
+            .withRequestBody(matchingJsonPath("awards[2].sanctionType", equalTo("PP")))
+            .withRequestBody(matchingJsonPath("awards[2].sanctionStatus", equalTo("SUSPENDED")))
+            .withRequestBody(matchingJsonPath("awards[2].effectiveDate", equalTo("2023-10-18")))
+            .withRequestBody(matchingJsonPath("awards[2].sanctionDays", equalTo("0"))),
         )
       }
 
@@ -153,7 +170,10 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
               .withRequestBody(matchingJsonPath("punishments[0].dpsPunishmentId", equalTo("634")))
               .withRequestBody(matchingJsonPath("punishments[1].nomisBookingId", equalTo("12345")))
               .withRequestBody(matchingJsonPath("punishments[1].nomisSanctionSequence", equalTo("11")))
-              .withRequestBody(matchingJsonPath("punishments[1].dpsPunishmentId", equalTo("667"))),
+              .withRequestBody(matchingJsonPath("punishments[1].dpsPunishmentId", equalTo("667")))
+              .withRequestBody(matchingJsonPath("punishments[2].nomisBookingId", equalTo("12345")))
+              .withRequestBody(matchingJsonPath("punishments[2].nomisSanctionSequence", equalTo("12")))
+              .withRequestBody(matchingJsonPath("punishments[2].dpsPunishmentId", equalTo("668"))),
           )
         }
       }
@@ -183,6 +203,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 3,
+                    "duration": 3,
                     "startDate": "2023-10-04",
                     "endDate": "2023-10-06",
                     "measurement": "DAYS"
@@ -194,6 +215,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 2,
+                    "duration": 2,
                     "measurement": "DAYS"
                 },
                 "consecutiveChargeNumber": "$CONSECUTIVE_CHARGE_NUMBER",
@@ -564,6 +586,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 3,
+                    "duration": 3,
                     "startDate": "2023-10-04",
                     "endDate": "2023-10-06",
                     "measurement": "DAYS"
@@ -575,6 +598,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 12,
+                    "duration": 12,
                     "suspendedUntil": "2023-10-18",
                     "measurement": "DAYS"
                 }
@@ -1291,6 +1315,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 3,
+                    "duration": 3,
                     "startDate": "2023-10-04",
                     "endDate": "2023-10-06",
                     "measurement": "DAYS"
@@ -1302,6 +1327,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 12,
+                    "duration": 12,
                     "suspendedUntil": "2023-10-18",
                     "measurement": "DAYS"
                 }
@@ -1409,6 +1435,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 3,
+                    "duration": 3,
                     "startDate": "2023-10-04",
                     "endDate": "2023-10-06",
                     "measurement": "DAYS"
@@ -1420,6 +1447,7 @@ class PunishmentsToNomisIntTest : SqsIntegrationTestBase() {
                 "rehabilitativeActivities": [],
                 "schedule": {
                     "days": 12,
+                    "duration": 12,
                     "suspendedUntil": "2023-10-18",
                     "measurement": "DAYS"
                 }


### PR DESCRIPTION
`days` is deprecated. Also with the unit measurement is hours set duration to 0 since NOMIS does not understand hours