### PR TITLE
SDIT-1803 Kubernetes metadata name has a limit of 52 chars

### DIFF
--- a/helm_deploy/hmpps-prisoner-to-nomis-update/templates/activities-tidy-mappings-cronjob.yaml
+++ b/helm_deploy/hmpps-prisoner-to-nomis-update/templates/activities-tidy-mappings-cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "app.fullname" . }}-activities-tidy-mappings
+  name: {{ include "app.fullname" . }}-activities-mappings
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
![image](https://github.com/ministryofjustice/hmpps-prisoner-to-nomis-update/assets/58170926/94ff5346-ab3c-444e-855a-e6a13c90d93f)
