### PR TITLE
SDIT-1836 Remove logic to delete mappings due to a prisoner merge

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsService.kt
@@ -128,12 +128,7 @@ class AlertsService(
         throw e
       }
     } else {
-      if (alertEvent.wasDeletedDueToMerge()) {
-        tryToDeletedMapping(dpsAlertId)
-        telemetryClient.trackEvent("alert-deleted-merge", telemetryMap)
-      } else {
-        telemetryClient.trackEvent("alert-deleted-ignored", telemetryMap)
-      }
+      telemetryClient.trackEvent("alert-deleted-ignored", telemetryMap)
     }
   }
 
@@ -176,5 +171,4 @@ enum class AlertReason {
 fun AlertEvent.wasCreatedInDPS() = wasSourceDPS()
 fun AlertEvent.wasUpdateInDPS() = wasSourceDPS()
 fun AlertEvent.wasDeletedInDPS() = wasSourceDPS()
-fun AlertEvent.wasDeletedDueToMerge() = this.additionalInformation.reason == AlertReason.MERGE
 fun AlertEvent.wasSourceDPS() = this.additionalInformation.source == AlertSource.DPS

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsToNomisIntTest.kt
@@ -493,37 +493,6 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
           alertsNomisApi.verify(0, deleteRequestedFor(anyUrl()))
         }
       }
-
-      @Nested
-      inner class WhenDeletedDueToMerge {
-        private val dpsAlertId = "bd91f2ac-6840-4fa1-8d7b-90d5a85d35c2"
-
-        @BeforeEach
-        fun setup() {
-          alertsMappingApi.stubDeleteByDpsId(dpsAlertId)
-          publishDeleteAlertDomainEvent(source = AlertSource.NOMIS, reason = AlertReason.MERGE, alertUuid = dpsAlertId)
-          waitForAnyProcessingToComplete()
-        }
-
-        @Test
-        fun `will send telemetry event showing it removed the mapping`() {
-          verify(telemetryClient).trackEvent(
-            eq("alert-deleted-merge"),
-            any(),
-            isNull(),
-          )
-        }
-
-        @Test
-        fun `will not try to delete the Alert in NOMIS`() {
-          alertsNomisApi.verify(0, deleteRequestedFor(anyUrl()))
-        }
-
-        @Test
-        fun `will delete the alert mapping`() {
-          alertsMappingApi.verify(deleteRequestedFor(urlEqualTo("/mapping/alerts/dps-alert-id/$dpsAlertId")))
-        }
-      }
     }
 
     @Nested


### PR DESCRIPTION
This logic has move the synchronisation from NOMIS where they actual merge takes place