### PR TITLE
SDIT-1903 Location working capacity does not sync correctly to Nomis

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/locations/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/locations/LocationsService.kt
@@ -69,7 +69,7 @@ class LocationsService(
   suspend fun amendLocation(event: LocationDomainEvent) {
     doUpdateLocation(event, "amend") { nomisLocationId, location ->
       nomisApiService.updateLocation(nomisLocationId, toUpdateLocationRequest(location))
-      nomisApiService.updateLocationCapacity(nomisLocationId, UpdateCapacityRequest(location.capacity?.maxCapacity, location.capacity?.maxCapacity))
+      nomisApiService.updateLocationCapacity(nomisLocationId, UpdateCapacityRequest(location.capacity?.maxCapacity, location.capacity?.workingCapacity))
       nomisApiService.updateLocationCertification(
         nomisLocationId,
         UpdateCertificationRequest(location.certification?.capacityOfCertifiedCell ?: 0, location.certification?.certified ?: false),


### PR DESCRIPTION
Fixes MAP-1430: Sync Bug: When changing the working capacity in our service the value is not reflected on NOMIS in the operational capacity. The op cap is always set to the max cap