### PR TITLE
SDIT-2026 Handle visit fails due to a duplicate detected

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsServiceTest.kt
@@ -41,7 +41,7 @@ internal class VisitsServiceTest {
     fun `should log a processed visit booked event`() = runTest {
       whenever(visitApiService.getVisit("123")).thenReturn(newVisit())
       whenever(mappingService.getMappingGivenVsipIdOrNull("123")).thenReturn(null)
-      whenever(nomisApiService.createVisit(any())).thenReturn(CreateVisitResponseDto("456"))
+      whenever(nomisApiService.createVisit(any())).thenReturn(Result.success(CreateVisitResponseDto("456")))
 
       visitsService.createVisit(
         VisitBookedEvent(
@@ -92,7 +92,7 @@ internal class VisitsServiceTest {
     fun `should log a mapping creation failure`() = runTest {
       whenever(visitApiService.getVisit("123")).thenReturn(newVisit())
       whenever(mappingService.getMappingGivenVsipIdOrNull("123")).thenReturn(null)
-      whenever(nomisApiService.createVisit(any())).thenReturn(CreateVisitResponseDto("456"))
+      whenever(nomisApiService.createVisit(any())).thenReturn(Result.success(CreateVisitResponseDto("456")))
       whenever(mappingService.createMapping(any())).thenThrow(RuntimeException("test"))
 
       visitsService.createVisit(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/MappingMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/MappingMockServer.kt
@@ -150,6 +150,31 @@ class MappingMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
+  fun stubGetVsipWithErrorFollowedBySuccess(vsipId: String, response: String, status: Int = 404) {
+    stubFor(
+      get("/mapping/visits/vsipId/$vsipId")
+        .inScenario("Check Mapping Visit Scenario")
+        .whenScenarioStateIs(Scenario.STARTED)
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status),
+        ).willSetStateTo("Cause Mapping Visit Success"),
+    )
+
+    stubFor(
+      get("/mapping/visits/vsipId/$vsipId")
+        .inScenario("Check Mapping Visit Scenario")
+        .whenScenarioStateIs("Cause Mapping Visit Success")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(response),
+        ).willSetStateTo(Scenario.STARTED),
+    )
+  }
+
   fun stubCreateIncentive() {
     stubFor(
       post("/mapping/incentives").willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
@@ -90,6 +90,27 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
+  fun stubVisitCreateWithDuplicateError(prisonerId: String, nomisVisitId: Long) {
+    stubFor(
+      post("/prisoners/$prisonerId/visits").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(
+            // language=JSON
+            """
+              { 
+                "status": 409, 
+                "userMessage": "Visit already exists $nomisVisitId",
+                "developerMessage": "Visit already exists $nomisVisitId",
+                "moreInfo": "$nomisVisitId"
+              }
+            """.trimIndent(),
+          )
+          .withStatus(409),
+      ),
+    )
+  }
+
   fun stubVisitCancel(prisonerId: String, visitId: String = "1234") {
     stubFor(
       put("/prisoners/$prisonerId/visits/$visitId/cancel").willReturn(


### PR DESCRIPTION
When the NOMIS API returns a 409 it means the request to create a visit has been rejected due to the visit already existing. The error response will contain the existing NOMIS visit id.

In the is scenario the mapping may have never been created; so use this opportunity to create it now. Else it has been created via a duplicate domain event so nothing more is needed