### PR TITLE
SDIT-2026 Handle visit fails due to a duplicate detected

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
@@ -79,16 +79,15 @@ class NomisApiService(
 
   // ////////// VISITS //////////////
 
-  suspend fun createVisit(request: CreateVisitDto): Result<CreateVisitResponseDto> =
+  suspend fun createVisit(request: CreateVisitDto): CreateVisitResponseDto =
     webClient.post()
       .uri("/prisoners/{offenderNo}/visits", request.offenderNo)
       .bodyValue(request)
       .retrieve()
       .bodyToMono(CreateVisitResponseDto::class.java)
-      .map { Result.success(it) }
       .onErrorResume(WebClientResponseException.Conflict::class.java) {
         val errorResponse = it.getResponseBodyAs(ErrorResponse::class.java) as ErrorResponse
-        Mono.just(Result.failure(CreateVisitDuplicateResponse(nomisVisitId = errorResponse.moreInfo!!)))
+        throw CreateVisitDuplicateResponse(nomisVisitId = errorResponse.moreInfo!!)
       }
       .awaitSingle()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsServiceTest.kt
@@ -41,7 +41,7 @@ internal class VisitsServiceTest {
     fun `should log a processed visit booked event`() = runTest {
       whenever(visitApiService.getVisit("123")).thenReturn(newVisit())
       whenever(mappingService.getMappingGivenVsipIdOrNull("123")).thenReturn(null)
-      whenever(nomisApiService.createVisit(any())).thenReturn(Result.success(CreateVisitResponseDto("456")))
+      whenever(nomisApiService.createVisit(any())).thenReturn(CreateVisitResponseDto("456"))
 
       visitsService.createVisit(
         VisitBookedEvent(
@@ -92,7 +92,7 @@ internal class VisitsServiceTest {
     fun `should log a mapping creation failure`() = runTest {
       whenever(visitApiService.getVisit("123")).thenReturn(newVisit())
       whenever(mappingService.getMappingGivenVsipIdOrNull("123")).thenReturn(null)
-      whenever(nomisApiService.createVisit(any())).thenReturn(Result.success(CreateVisitResponseDto("456")))
+      whenever(nomisApiService.createVisit(any())).thenReturn(CreateVisitResponseDto("456"))
       whenever(mappingService.createMapping(any())).thenThrow(RuntimeException("test"))
 
       visitsService.createVisit(


### PR DESCRIPTION
When the NOMIS API returns a 409 it means the request to create a visit has been rejected due to the visit already existing. The error response will contain the existing NOMIS visit id.

In the is scenario the mapping may have never been created; so use this opportunity to create it now. Else it has been created via a duplicate domain event so nothing more is needed