### PR TITLE
SDIT-2023 Synchronise height and weight from DPS when a prisoner is readmitted on an old booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/prisonperson/PrisonPersonDomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/prisonperson/PrisonPersonDomainEventListener.kt
@@ -36,6 +36,7 @@ class PrisonPersonDomainEventListener(
   ): CompletableFuture<Void> = onDomainEvent(rawMessage) { eventType, message ->
     when (eventType) {
       "prison-person.physical-attributes.updated" -> physicalAttributesSyncService.updatePhysicalAttributesEvent(message.fromJson())
+      "prisoner-offender-search.prisoner.received" -> physicalAttributesSyncService.readmissionSwitchBookingEvent(message.fromJson())
       else -> log.info("Received a message I wasn't expecting: {}", eventType)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/prisonperson/physicalattributes/PhysicalAttributesSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/prisonperson/physicalattributes/PhysicalAttributesSyncService.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.prisonperson.physicalattributes
 
 import com.microsoft.applicationinsights.TelemetryClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.listeners.EventFeatureSwitch
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.prisonperson.model.PhysicalAttributesSyncDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.prisonperson.profiledetails.ProfileDetailsNomisApiService
 
@@ -11,6 +14,7 @@ class PhysicalAttributesSyncService(
   private val dpsApi: PhysicalAttributesDpsApiService,
   private val physicalAttributesNomisApi: PhysicalAttributesNomisApiService,
   private val profileDetailsNomisApi: ProfileDetailsNomisApiService,
+  private val eventFeatureSwitch: EventFeatureSwitch,
   private val telemetryClient: TelemetryClient,
 ) {
 
@@ -40,6 +44,20 @@ class PhysicalAttributesSyncService(
       )
       throw e
     }
+
+  suspend fun readmissionSwitchBookingEvent(event: PrisonerReceivedEvent) {
+    // We should be able to filter for this reason in the Topic subscription filter, but this is just in case
+    if (event.additionalInformation.reason != "READMISSION_SWITCH_BOOKING") return
+
+    // We only synchronise a readmission back to NOMIS if the DPS to NOMIS sync is turned on
+    if (!eventFeatureSwitch.isEnabled("prison-person.physical-attributes.updated")) {
+      log.info("Physical attributes sync is disabled, ignoring readmission event for offenderNo: ${event.additionalInformation.nomsNumber}")
+      return
+    }
+
+    // For now we only sync back the height and weight, but will add profile details when they are proven to be required too
+    updatePhysicalAttributes(event.additionalInformation.nomsNumber, listOf("HEIGHT", "WEIGHT"))
+  }
 
   private suspend fun updateNomis(offenderNo: String, dpsAttributes: PhysicalAttributesSyncDto, fields: List<String>?) {
     if (fields == null || "HEIGHT" in fields || "WEIGHT" in fields) {
@@ -108,6 +126,10 @@ class PhysicalAttributesSyncService(
       "SHOE_SIZE" -> shoeSize
       else -> throw ProfileDetailsSyncException("Unknown field: $field")
     }
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
 }
 
 data class PhysicalAttributesDomainEvent(
@@ -121,6 +143,18 @@ data class PhysicalAttributesAdditionalInformation(
   val source: String,
   val prisonerNumber: String,
   val fields: List<String>?,
+)
+
+data class PrisonerReceivedEvent(
+  val eventType: String,
+  val version: String,
+  val description: String,
+  val additionalInformation: PrisonerReceivedEventAdditionalInformation,
+)
+
+data class PrisonerReceivedEventAdditionalInformation(
+  val reason: String,
+  val nomsNumber: String,
 )
 
 class ProfileDetailsSyncException(message: String) : RuntimeException(message)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -216,7 +216,8 @@ hmpps.sqs:
       subscribeTopicId: domainevents
       subscribeFilter: >-
         { "eventType":[
-          "prison-person.physical-attributes.updated"
+          "prison-person.physical-attributes.updated",
+          "prisoner-offender-search.prisoner.received"
         ]}
       dlqMaxReceiveCount: 3
       visibilityTimeout: 120


### PR DESCRIPTION
This handles an edge case where a prisoner is recalled but received on a new booking. When the mistake is noticed the new booking is ended and the prisoner is received again on the correct old booking. If the prisoner was re-measured on the new booking then DPS will have been updated but NOMIS loses this information. Therefore, whenever this happens we know DPS has the most up-to-date measurements so we synchronise from DPS back to NOMIS to keep NOMIS in line.