### PR TITLE
SDIT-2323 Repair can now propagate active status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsDataRepairResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsDataRepairResource.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.prisonertonomisupdate.sentencing
 
 import com.microsoft.applicationinsights.TelemetryClient
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -24,8 +26,10 @@ class SentencingAdjustmentsDataRepairResource(
   suspend fun repairAdjustments(
     @PathVariable offenderNo: String,
     @PathVariable adjustmentId: String,
+    @Schema(description = "Whether status of the DPS should be propagated to NOMIS", required = false, defaultValue = "false")
+    @RequestParam(name = "force-status", defaultValue = "false") forceStatus: Boolean,
   ) {
-    sentencingAdjustmentsService.repairAdjustment(offenderNo = offenderNo, adjustmentId = adjustmentId)
+    sentencingAdjustmentsService.repairAdjustment(offenderNo = offenderNo, adjustmentId = adjustmentId, forceStatus = forceStatus)
     telemetryClient.trackEvent(
       "to-nomis-synch-adjustment-repair",
       mapOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/services/NomisApiService.kt
@@ -806,6 +806,7 @@ data class UpdateSentencingAdjustmentRequest(
   val adjustmentDays: Long,
   val sentenceSequence: Int?,
   val comment: String?,
+  val active: Boolean? = null,
 )
 
 data class CreateSentencingAdjustmentResponse(val id: Long)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsToNomisIntTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.sentencing
 
+import com.github.tomakehurst.wiremock.client.WireMock.absent
 import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
@@ -820,6 +821,7 @@ class SentencingAdjustmentsToNomisTest : SqsIntegrationTestBase() {
                 .withRequestBody(matchingJsonPath("adjustmentDays", equalTo("99")))
                 .withRequestBody(matchingJsonPath("adjustmentFromDate", equalTo("2020-07-19")))
                 .withRequestBody(matchingJsonPath("sentenceSequence", equalTo("$sentenceSequence")))
+                .withRequestBody(matchingJsonPath("active", absent()))
                 .withRequestBody(matchingJsonPath("comment", equalTo("Adjusted for remand"))),
             )
           }
@@ -879,6 +881,7 @@ class SentencingAdjustmentsToNomisTest : SqsIntegrationTestBase() {
                 .withRequestBody(matchingJsonPath("adjustmentDate", equalTo("2022-01-01")))
                 .withRequestBody(matchingJsonPath("adjustmentDays", equalTo("99")))
                 .withRequestBody(matchingJsonPath("adjustmentFromDate", equalTo("2020-07-19")))
+                .withRequestBody(matchingJsonPath("active", absent()))
                 .withRequestBody(matchingJsonPath("comment", equalTo("Adjusted for absence"))),
             )
           }


### PR DESCRIPTION
The active status does not by default ever get propagated from DPS to NOMIS.

However, when repairing an adjustment where the status is correct in DPS but not NOMIS we maye wish NOMIS to replicate the DPS status