### PR TITLE
SDIT-2336 endpoint to repair NOMIS alerts from DPS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDataRepairResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDataRepairResource.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.alerts
+
+import com.microsoft.applicationinsights.TelemetryClient
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AlertsDataRepairResource(
+  private val alertsService: AlertsService,
+  private val telemetryClient: TelemetryClient,
+) {
+  @PostMapping("/prisoners/{offenderNo}/alerts/resynchronise")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_MIGRATE_ALERTS')")
+  @Operation(
+    summary = "Resynchronises current alerts for the given prisoner from DPS back to current booking in NOMIS",
+    description = "Used when an unexpected event has happened in DPS that has resulted in the NOMIS data drifting from DPS, so emergency use only. Requires ROLE_MIGRATE_ALERTS",
+  )
+  suspend fun repairAlerts(
+    @PathVariable offenderNo: String,
+  ) {
+    alertsService.resynchronisePrisonerAlerts(offenderNo)
+    telemetryClient.trackEvent(
+      "to-nomis-synch-alerts-resynchronisation-repair",
+      mapOf(
+        "offenderNo" to offenderNo,
+      ),
+      null,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDpsApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDpsApiService.kt
@@ -39,6 +39,24 @@ class AlertsDpsApiService(@Qualifier("alertsApiWebClient") private val webClient
         it.content
       }
 
+  suspend fun getAllAlertsForPrisoner(offenderNo: String): List<Alert> =
+    webClient
+      .get()
+      .uri {
+        it.path("/prisoners/{offenderNo}/alerts")
+          .queryParam("page", 0)
+          .queryParam("size", 1000)
+          .build(offenderNo)
+      }
+      .retrieve()
+      .bodyToMono(typeReference<RestResponsePage<Alert>>())
+      .awaitSingle().let {
+        // since a person can not typically have multiple active alerts the page size needs to be as big as the number of different alert codes (213)
+        // so give it a reasonable headroom for growth and in the unlikely event of exceeding the size than throw an error and we can increase size with a code change
+        if (it.totalElements != it.numberOfElements.toLong()) throw IllegalStateException("Page size of 1000 for /prisoners/{offenderNo}/alerts not big enough ${it.totalElements} not equal to ${it.numberOfElements}")
+        it.content
+      }
+
   suspend fun getAlertCode(code: String): AlertCode = webClient
     .get()
     .uri("/alert-codes/{code}", code)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiService.kt
@@ -6,6 +6,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyOrNullForNotFound
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.AlertMappingDto
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.PrisonerAlertMappingsDto
 
 @Service
 class AlertsMappingApiService(@Qualifier("mappingWebClient") private val webClient: WebClient) {
@@ -30,6 +31,19 @@ class AlertsMappingApiService(@Qualifier("mappingWebClient") private val webClie
       .uri(
         "/mapping/alerts/dps-alert-id/{alertId}",
         alertId,
+      )
+      .retrieve()
+      .awaitBodilessEntity()
+  }
+
+  suspend fun replaceMappings(
+    offenderNo: String,
+    prisonerMapping: PrisonerAlertMappingsDto,
+  ) {
+    webClient.put()
+      .uri("/mapping/alerts/{offenderNo}/all", offenderNo)
+      .bodyValue(
+        prisonerMapping,
       )
       .retrieve()
       .awaitBodilessEntity()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiService.kt
@@ -45,6 +45,15 @@ class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClien
       .awaitBodilessEntity()
   }
 
+  suspend fun resynchroniseAlerts(offenderNo: String, nomisAlerts: List<CreateAlertRequest>): List<CreateAlertResponse> = webClient.post()
+    .uri(
+      "/prisoners/{offenderNo}/alerts/resynchronise",
+      offenderNo,
+    )
+    .bodyValue(nomisAlerts)
+    .retrieve()
+    .awaitBody()
+
   suspend fun getAlertsForReconciliation(offenderNo: String): PrisonerAlertsResponse =
     webClient.get().uri(
       "/prisoners/{offenderNo}/alerts/reconciliation",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDataRepairResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDataRepairResourceIntTest.kt
@@ -1,0 +1,155 @@
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.alerts
+
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.eq
+import org.mockito.kotlin.check
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.alerts.AlertsDpsApiExtension.Companion.alertsDpsApi
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.withRequestBodyJsonPath
+import java.time.LocalDate
+import java.util.*
+
+class AlertsDataRepairResourceIntTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var alertsNomisApiMockServer: AlertsNomisApiMockServer
+
+  @Autowired
+  private lateinit var alertsMappingApiMockServer: AlertsMappingApiMockServer
+
+  @DisplayName("POST /prisoners/{offenderNo}/alerts/resynchronise")
+  @Nested
+  inner class RepairAlerts {
+    val offenderNo = "A1234KT"
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/alerts/resynchronise")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/alerts/resynchronise")
+          .headers(setAuthorisation(roles = listOf("BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/alerts/resynchronise")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      val offenderNo = "A1234KT"
+      val bookingId = 1234L
+      private val dpsAlertId1 = UUID.fromString("956d4326-b0c3-47ac-ab12-f0165109a6c5")
+      private val dpsAlertId2 = UUID.fromString("f612a10f-4827-4022-be96-d882193dfabd")
+
+      @BeforeEach
+      fun setUp() {
+        alertsDpsApi.stubGetAllAlertsForPrisoner(
+          offenderNo,
+          dpsAlert().copy(
+            alertUuid = dpsAlertId1,
+            alertCode = dpsAlertCode("A"),
+            isActive = false,
+            activeTo = LocalDate.parse("2023-01-01"),
+          ),
+          dpsAlert().copy(
+            alertUuid = dpsAlertId2,
+            alertCode = dpsAlertCode("B"),
+            isActive = true,
+          ),
+        )
+        alertsNomisApiMockServer.stubResynchroniseAlerts(
+          offenderNo = offenderNo,
+          alerts = listOf(
+            createAlertResponse().copy(bookingId = bookingId, alertSequence = 1),
+            createAlertResponse().copy(bookingId = bookingId, alertSequence = 2),
+          ),
+        )
+        alertsMappingApiMockServer.stubReplaceMappings(offenderNo)
+
+        webTestClient.post().uri("/prisoners/$offenderNo/alerts/resynchronise")
+          .headers(setAuthorisation(roles = listOf("MIGRATE_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+      }
+
+      @Test
+      fun `will retrieve current alerts for the prisoner`() {
+        alertsDpsApi.verify(getRequestedFor(urlPathEqualTo("/prisoners/$offenderNo/alerts")))
+      }
+
+      @Test
+      fun `will send all alerts to NOMIS`() {
+        alertsNomisApiMockServer.verify(
+          postRequestedFor(urlPathEqualTo("/prisoners/$offenderNo/alerts/resynchronise"))
+            .withRequestBodyJsonPath("[0].alertCode", "A")
+            .withRequestBodyJsonPath("[0].isActive", "false")
+            .withRequestBodyJsonPath("[0].expiryDate", "2023-01-01")
+            .withRequestBodyJsonPath("[1].alertCode", "B")
+            .withRequestBodyJsonPath("[1].isActive", "true"),
+        )
+      }
+
+      @Test
+      fun `will replaces mapping between the DPS and NOMIS alerts`() {
+        alertsMappingApiMockServer.verify(
+          putRequestedFor(urlPathEqualTo("/mapping/alerts/$offenderNo/all"))
+            .withRequestBodyJsonPath("mappingType", "DPS_CREATED")
+            .withRequestBodyJsonPath("mappings[0].nomisBookingId", "$bookingId")
+            .withRequestBodyJsonPath("mappings[0].nomisAlertSequence", "1")
+            .withRequestBodyJsonPath("mappings[0].dpsAlertId", "$dpsAlertId1")
+            .withRequestBodyJsonPath("mappings[1].nomisBookingId", "$bookingId")
+            .withRequestBodyJsonPath("mappings[1].nomisAlertSequence", "2")
+            .withRequestBodyJsonPath("mappings[1].dpsAlertId", "$dpsAlertId2"),
+        )
+      }
+
+      @Test
+      fun `will track telemetry for the resynchronise`() {
+        verify(telemetryClient).trackEvent(
+          eq("alert-resynchronise-success"),
+          check {
+            assertThat(it["offenderNo"]).isEqualTo(offenderNo)
+            assertThat(it["alertsCount"]).isEqualTo("2")
+            assertThat(it["alerts"]).isEqualTo("1,2")
+          },
+          isNull(),
+        )
+      }
+
+      @Test
+      fun `will track telemetry for the repair`() {
+        verify(telemetryClient).trackEvent(
+          eq("to-nomis-synch-alerts-resynchronisation-repair"),
+          check {
+            assertThat(it["offenderNo"]).isEqualTo(offenderNo)
+          },
+          isNull(),
+        )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDpsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDpsApiMockServer.kt
@@ -25,7 +25,10 @@ import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.math.min
 
-class AlertsDpsApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+class AlertsDpsApiExtension :
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback {
   companion object {
     @JvmField
     val alertsDpsApi = AlertsDpsApiMockServer()
@@ -123,6 +126,42 @@ class AlertsDpsApiMockServer : WireMockServer(WIREMOCK_PORT) {
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
             .withBody(error),
+        ),
+    )
+  }
+
+  fun stubGetAllAlertsForPrisoner(offenderNo: String, count: Int = 1) {
+    stubFor(
+      get(urlPathEqualTo("/prisoners/$offenderNo/alerts"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              PageImpl(
+                (1..min(count, 1000)).map { dpsAlert() },
+                Pageable.ofSize(1000),
+                count.toLong(),
+              ),
+            )
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubGetAllAlertsForPrisoner(offenderNo: String, vararg alerts: Alert) {
+    stubFor(
+      get(urlPathEqualTo("/prisoners/$offenderNo/alerts"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              PageImpl(
+                alerts.toList(),
+                Pageable.ofSize(1000),
+                alerts.size.toLong(),
+              ),
+            )
+            .withStatus(200),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsMappingApiMockServer.kt
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.delete
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.put
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
@@ -118,6 +119,16 @@ class AlertsMappingApiMockServer(private val objectMapper: ObjectMapper) {
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(HttpStatus.NO_CONTENT.value()),
+      ),
+    )
+  }
+
+  fun stubReplaceMappings(offenderNo: String) {
+    mappingServer.stubFor(
+      put("/mapping/alerts/$offenderNo/all").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(200),
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiMockServer.kt
@@ -36,6 +36,20 @@ class AlertsNomisApiMockServer(private val objectMapper: ObjectMapper) {
     )
   }
 
+  fun stubResynchroniseAlerts(
+    offenderNo: String = "A1234AK",
+    alerts: List<CreateAlertResponse> = listOf(createAlertResponse()),
+  ) {
+    nomisApi.stubFor(
+      post(urlEqualTo("/prisoners/$offenderNo/alerts/resynchronise")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.CREATED.value())
+          .withBody(objectMapper.writeValueAsString(alerts)),
+      ),
+    )
+  }
+
   fun stubPutAlert(
     bookingId: Long = 12345678,
     alertSequence: Long = 3,


### PR DESCRIPTION
* Gets all alerts in DPS (including inactive)
* Calls NOMIS API that will replace the alerts on the current booking
* Replaces the mappings for that prisoner