### PR TITLE
SDIT-2336 endpoint to repair NOMIS alerts from DPS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsService.kt
@@ -140,6 +140,8 @@ class AlertsService(
   }
 
   suspend fun resynchronisePrisonerAlerts(offenderNo: String) {
+    // clear al mappings so now deletes are processed by the migration service
+    mappingApiService.replaceMappings(offenderNo, PrisonerAlertMappingsDto(mappingType = PrisonerAlertMappingsDto.MappingType.DPS_CREATED, mappings = emptyList()))
     val dpsAlerts = dpsApiService.getAllAlertsForPrisoner(offenderNo)
     val nomisAlerts = nomisApiService.resynchroniseAlerts(offenderNo, dpsAlerts.map { it.toNomisCreateRequest() })
     val mappings = nomisAlerts.zip(dpsAlerts).map { (nomisAlert, dpsAlert) -> AlertMappingIdDto(dpsAlert.alertUuid.toString(), nomisAlert.bookingId, nomisAlert.alertSequence) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDataRepairResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsDataRepairResourceIntTest.kt
@@ -97,6 +97,14 @@ class AlertsDataRepairResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
+      fun `will clear mappings between the DPS and NOMIS alerts`() {
+        alertsMappingApiMockServer.verify(
+          putRequestedFor(urlPathEqualTo("/mapping/alerts/$offenderNo/all"))
+            .withRequestBodyJsonPath("mappings.size()", "0"),
+        )
+      }
+
+      @Test
       fun `will retrieve current alerts for the prisoner`() {
         alertsDpsApi.verify(getRequestedFor(urlPathEqualTo("/prisoners/$offenderNo/alerts")))
       }


### PR DESCRIPTION
Clears the mappings before the delete so no delete will be processed by the "from nomis" service