### PR TITLE
SDIT-2384 Adjustments reconciliation use different paging strategy

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingReconciliationService.kt
@@ -10,10 +10,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.BookingIdsWithLast
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.PrisonerIds
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.sentencing.adjustments.model.AdjustmentDto.AdjustmentType
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.asPages
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.awaitBoth
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.doApiCallWithRetries
 
@@ -31,35 +31,52 @@ class SentencingReconciliationService(
     val remandAdjustmentTypes = listOf("RSR", "RX")
   }
 
-  suspend fun generateReconciliationReport(allPrisoners: Boolean, activePrisonersCount: Long): List<MismatchSentencingAdjustments> = activePrisonersCount.asPages(pageSize).flatMap { page ->
-    val activePrisoners = getActivePrisonersForPage(allPrisoners, page)
+  suspend fun generateReconciliationReport(allPrisoners: Boolean): List<MismatchSentencingAdjustments> {
+    val mismatches: MutableList<MismatchSentencingAdjustments> = mutableListOf()
+    var lastBookingId = 0L
 
-    withContext(Dispatchers.Unconfined) {
-      activePrisoners.map { async { checkBookingAdjustmentsMatch(it) } }
-    }.awaitAll().filterNotNull()
+    do {
+      val page = getNextBookingsForPage(lastBookingId, allPrisoners)
+      page?.takeIf { it.prisonerIds.isNotEmpty() }?.also {
+        it.checkPageOfBookingAdjustmentsMatch().also { result ->
+          mismatches += result.mismatches
+          lastBookingId = result.lastBookingId
+        }
+      } ?: run {
+        // just skip this "page" by moving the bookingId pointer up
+        lastBookingId += pageSize.toInt()
+      }
+    } while (page.notLastPage())
+
+    return mismatches.toList()
   }
 
-  // TODO - feature switch getActivePrisoners get all prisoners
-  private suspend fun getActivePrisonersForPage(@Suppress("UNUSED_PARAMETER") allPrisoners: Boolean, page: Pair<Long, Long>) =
-    runCatching {
-      doApiCallWithRetries {
-        nomisApiService.getActivePrisoners(
-          pageNumber = page.first,
-          pageSize = page.second,
-        )
-      }.content
-    }
+  private suspend fun BookingIdsWithLast.checkPageOfBookingAdjustmentsMatch(): MismatchPageResult {
+    val prisonerIds = this.prisonerIds
+    val mismatches = withContext(Dispatchers.Unconfined) {
+      prisonerIds.map { async { checkBookingAdjustmentsMatch(it) } }
+    }.awaitAll().filterNotNull()
+    return MismatchPageResult(mismatches, prisonerIds.last().bookingId)
+  }
+
+  data class MismatchPageResult(val mismatches: List<MismatchSentencingAdjustments>, val lastBookingId: Long)
+
+  // Last page will be a non-null page with items less than page size
+  private fun BookingIdsWithLast?.notLastPage(): Boolean = this == null || this.prisonerIds.size == pageSize.toInt()
+
+  private suspend fun getNextBookingsForPage(lastBookingId: Long, allPrisoners: Boolean): BookingIdsWithLast? =
+    runCatching { nomisApiService.getAllLatestBookings(lastBookingId = lastBookingId, activeOnly = !allPrisoners, pageSize = pageSize.toInt()) }
       .onFailure {
         telemetryClient.trackEvent(
           "sentencing-reports-reconciliation-mismatch-page-error",
           mapOf(
-            "page" to page.first.toString(),
+            "booking" to lastBookingId.toString(),
           ),
         )
-        log.error("Unable to match entire page of prisoners: $page", it)
+        log.error("Unable to match entire page of bookings from booking: $lastBookingId", it)
       }
-      .getOrElse { emptyList() }
-      .also { log.info("Page requested: $page, with ${it.size} active prisoners") }
+      .getOrNull()
+      .also { log.info("Page requested from booking: $lastBookingId, with $pageSize bookings") }
 
   suspend fun checkBookingAdjustmentsMatch(prisonerId: PrisonerIds): MismatchSentencingAdjustments? = runCatching {
     val (nomisAdjustments, dpsAdjustments) = withContext(Dispatchers.Unconfined) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/wiremock/NomisApiMockServer.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.delete
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
@@ -21,6 +22,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.objectMapper
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.AdjudicationADAAwardSummaryResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.BookingIdsWithLast
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.CreateCourtCaseResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.MergeDetail
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomissync.model.PrisonerId
@@ -2240,6 +2242,60 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
           .withHeader("Content-Type", "application/json")
           .withStatus(200),
       ),
+    )
+  }
+
+  fun stuGetAllLatestBookings(
+    response: BookingIdsWithLast = BookingIdsWithLast(
+      lastBookingId = 0,
+      prisonerIds = emptyList(),
+    ),
+  ) {
+    stubFor(
+      get(
+        urlPathEqualTo("/bookings/ids/latest-from-id"),
+      )
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(HttpStatus.OK.value())
+            .withBody(response),
+        ),
+    )
+  }
+
+  fun stuGetAllLatestBookings(
+    bookingId: Long,
+    response: BookingIdsWithLast = BookingIdsWithLast(
+      lastBookingId = 0,
+      prisonerIds = emptyList(),
+    ),
+  ) {
+    stubFor(
+      get(
+        urlPathEqualTo("/bookings/ids/latest-from-id"),
+      ).withQueryParam("bookingId", equalTo("$bookingId"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(HttpStatus.OK.value())
+            .withBody(response),
+        ),
+    )
+  }
+  fun stuGetAllLatestBookings(
+    bookingId: Long,
+    errorStatus: HttpStatus,
+  ) {
+    stubFor(
+      get(
+        urlPathEqualTo("/bookings/ids/latest-from-id"),
+      ).withQueryParam("bookingId", equalTo("$bookingId"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(errorStatus.value()),
+        ),
     )
   }
 


### PR DESCRIPTION
Previous this uses the NOMIS api /prisoners/ids using Spring paging. This has now switched the "last id" /bookings/ids method

This should improve performance once we switch the all latest bookings rather than the current active bookings