### PR TITLE
SDIT-2617 Adjudication repair endpoint.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsDataRepairResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/adjudications/AdjudicationsDataRepairResourceIntTest.kt
@@ -279,10 +279,11 @@ class AdjudicationsDataRepairResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `will call nomis api to create punishment award`() {
+      fun `will call nomis api to create punishment award with the latest hearing date`() {
         nomisApi.verify(
           postRequestedFor(urlEqualTo("/adjudications/adjudication-number/$ADJUDICATION_NUMBER/charge/1/awards"))
-            .withRequestBody(matchingJsonPath("awards[0].sanctionType", equalTo("ADA"))),
+            .withRequestBody(matchingJsonPath("awards[0].sanctionType", equalTo("ADA")))
+            .withRequestBody(matchingJsonPath("awards[0].effectiveDate", equalTo("2013-12-03"))),
         )
       }
 


### PR DESCRIPTION
Set punishment date to latest hearing date when not present.

Since this repairs a historic adjudication the punishment date would normally be "now" which is when the hearing is entered, but in this case it makes more sense to be the actual date the hearing took place, else a hearing for 10 years ago would have a punishment date of today