### PR TITLE
Minor tweaks to visitComment and visitOrderComment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsService.kt
@@ -63,7 +63,7 @@ class VisitsService(
                   "FAMILY" -> "SCON"
                   else -> throw ValidationException("Invalid visit type ${visit.visitType}")
                 },
-                visitComment = "Created by Book A Prison Visit. Reference: ${visit.reference}",
+                visitComment = "DPS booking reference: ${visit.reference}",
                 visitOrderComment = "DPS booking reference: ${visit.reference}",
                 room = visit.visitRoom,
                 openClosedStatus = visit.visitRestriction,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitsService.kt
@@ -64,7 +64,7 @@ class VisitsService(
                   else -> throw ValidationException("Invalid visit type ${visit.visitType}")
                 },
                 visitComment = "Created by Book A Prison Visit. Reference: ${visit.reference}",
-                visitOrderComment = "Created by Book A Prison Visit for visit with reference: ${visit.reference}",
+                visitOrderComment = "DPS booking reference: ${visit.reference}",
                 room = visit.visitRoom,
                 openClosedStatus = visit.visitRestriction,
               ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitToNomisTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/visits/VisitToNomisTest.kt
@@ -71,13 +71,13 @@ class VisitToNomisTest : SqsIntegrationTestBase() {
           .withRequestBody(
             matchingJsonPath(
               "visitComment",
-              equalTo("Created by Book A Prison Visit. Reference: 12"),
+              equalTo("DPS booking reference: 12"),
             ),
           )
           .withRequestBody(
             matchingJsonPath(
               "visitOrderComment",
-              equalTo("Created by Book A Prison Visit for visit with reference: 12"),
+              equalTo("DPS booking reference: 12"),
             ),
           ),
       )


### PR DESCRIPTION
We have made some minor changes to the `visitComment` and `visitOrderComment` fields to be more accurate. This shorter text also allows us to potentially add additional visit information to the sync for use in NOMIS reports.

Tests have also been updated.