### PR TITLE
SDIT-2766 Prisoner contact reconciliation now includes inactive contacts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonDpsApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonDpsApiService.kt
@@ -80,7 +80,7 @@ class ContactPersonDpsApiService(@Qualifier("personalRelationshipsApiWebClient")
     .awaitBody()
 
   suspend fun getPrisonerContacts(prisonNumber: String): PagedModelPrisonerContactSummary = webClient.get()
-    .uri("/prisoner/{prisonNumber}/contact?page=0&size=10000&active=true", prisonNumber)
+    .uri("/prisoner/{prisonNumber}/contact?page=0&size=10000", prisonNumber)
     .retrieve()
     .awaitBodyWithRetry(backoffSpec)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonNomisApiService.kt
@@ -329,7 +329,7 @@ class ContactPersonNomisApiService(
   }
 
   suspend fun getContactsForPrisoner(offenderNo: String): PrisonerWithContacts = webClient.get()
-    .uri("/prisoners/{offenderNo}/contacts?active-only={activeOnly}&latest-booking-only={latestBookingOnly}", offenderNo, true, true)
+    .uri("/prisoners/{offenderNo}/contacts?active-only={activeOnly}&latest-booking-only={latestBookingOnly}", offenderNo, false, true)
     .retrieve()
     .awaitBodyWithRetry(backoffSpec)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonReconciliationService.kt
@@ -423,6 +423,7 @@ class ContactPersonReconciliationService(
     emergencyContact = this.isEmergencyContact,
     nextOfKin = this.isNextOfKin,
     approvedVisitor = this.isApprovedVisitor,
+    active = this.isRelationshipActive,
   )
 
   private fun PrisonerContact.asSummary() = ContactSummary(
@@ -434,6 +435,7 @@ class ContactPersonReconciliationService(
     emergencyContact = this.emergencyContact,
     nextOfKin = this.nextOfKin,
     approvedVisitor = this.approvedVisitor,
+    active = this.active,
   )
 
   private fun ContactPerson.asSummary() = PersonSummary(
@@ -539,6 +541,7 @@ data class ContactSummary(
   val emergencyContact: Boolean,
   val nextOfKin: Boolean,
   val approvedVisitor: Boolean,
+  val active: Boolean,
 )
 data class PrisonerContactRestrictionSummary(
   val contactId: Long,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonDpsApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonDpsApiServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.personalrelationships
 
+import com.github.tomakehurst.wiremock.client.WireMock.absent
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
@@ -307,7 +308,7 @@ class ContactPersonDpsApiServiceTest {
     }
 
     @Test
-    fun `will request a single huge page of just active contacts`() = runTest {
+    fun `will request a single huge page of all contacts`() = runTest {
       dpsContactPersonServer.stubGetPrisonerContacts(prisonerNumber = "A1234KT")
 
       apiService.getPrisonerContacts("A1234KT")
@@ -316,7 +317,7 @@ class ContactPersonDpsApiServiceTest {
         getRequestedFor(anyUrl())
           .withQueryParam("size", equalTo("10000"))
           .withQueryParam("page", equalTo("0"))
-          .withQueryParam("active", equalTo("true")),
+          .withQueryParam("active", absent()),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonNomisApiServiceTest.kt
@@ -852,14 +852,14 @@ class ContactPersonNomisApiServiceTest {
     }
 
     @Test
-    fun `will request just active contacts`() = runTest {
+    fun `will request just active and inactive contacts`() = runTest {
       mockServer.stubGetPrisonerContacts(prisonerNumber = "A1234KT")
 
       apiService.getContactsForPrisoner("A1234KT")
 
       mockServer.verify(
         getRequestedFor(anyUrl())
-          .withQueryParam("active-only", equalTo("true"))
+          .withQueryParam("active-only", equalTo("false"))
           .withQueryParam("latest-booking-only", equalTo("true")),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonReconciliationServiceTest.kt
@@ -291,7 +291,7 @@ internal class ContactPersonReconciliationServiceTest {
       }
 
       @Test
-      fun `telemetry will show contact is missing`() = runTest {
+      fun `telemetry will show contact is different`() = runTest {
         service.checkPrisonerContactsMatch(prisonerId)
         verify(telemetryClient).trackEvent(
           eq("contact-person-prisoner-contact-reconciliation-mismatch"),
@@ -326,7 +326,7 @@ internal class ContactPersonReconciliationServiceTest {
       }
 
       @Test
-      fun `telemetry will show contact is missing`() = runTest {
+      fun `telemetry will show contact is different`() = runTest {
         service.checkPrisonerContactsMatch(prisonerId)
         verify(telemetryClient).trackEvent(
           eq("contact-person-prisoner-contact-reconciliation-mismatch"),
@@ -354,7 +354,7 @@ internal class ContactPersonReconciliationServiceTest {
       }
 
       @Test
-      fun `telemetry will show contact is missing`() = runTest {
+      fun `telemetry will show contact is different`() = runTest {
         service.checkPrisonerContactsMatch(prisonerId)
         verify(telemetryClient).trackEvent(
           eq("contact-person-prisoner-contact-reconciliation-mismatch"),
@@ -382,7 +382,7 @@ internal class ContactPersonReconciliationServiceTest {
       }
 
       @Test
-      fun `telemetry will show contact is missing`() = runTest {
+      fun `telemetry will show contact is different`() = runTest {
         service.checkPrisonerContactsMatch(prisonerId)
         verify(telemetryClient).trackEvent(
           eq("contact-person-prisoner-contact-reconciliation-mismatch"),
@@ -407,6 +407,18 @@ internal class ContactPersonReconciliationServiceTest {
           ),
         )
       }
+
+      @Test
+      fun `telemetry will show contact is different`() = runTest {
+        service.checkPrisonerContactsMatch(prisonerId)
+        verify(telemetryClient).trackEvent(
+          eq("contact-person-prisoner-contact-reconciliation-mismatch"),
+          check {
+            assertThat(it).containsEntry("reason", "different-contacts-details")
+          },
+          isNull(),
+        )
+      }
     }
 
     @Nested
@@ -424,7 +436,7 @@ internal class ContactPersonReconciliationServiceTest {
       }
 
       @Test
-      fun `telemetry will show contact is missing`() = runTest {
+      fun `telemetry will show contact is different`() = runTest {
         service.checkPrisonerContactsMatch(prisonerId)
         verify(telemetryClient).trackEvent(
           eq("contact-person-prisoner-contact-reconciliation-mismatch"),
@@ -451,7 +463,7 @@ internal class ContactPersonReconciliationServiceTest {
       }
 
       @Test
-      fun `telemetry will show contact is missing`() = runTest {
+      fun `telemetry will show contact is different`() = runTest {
         service.checkPrisonerContactsMatch(prisonerId)
         verify(telemetryClient).trackEvent(
           eq("contact-person-prisoner-contact-reconciliation-mismatch"),


### PR DESCRIPTION
In NOMIS inactive contacts have little meaning and half of them are created inactive