### PR TITLE
SDIT-2754 Show bookings in other prisons for allocation reconciliation but not suspended allocation reconciliation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesReconService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesReconService.kt
@@ -47,7 +47,7 @@ class ActivitiesReconService(
       val dpsBookingCounts = async { activitiesApiService.getAllocationReconciliation(prisonId) }
       val compareResults = compareBookingCounts(nomisBookingCounts.await(), dpsBookingCounts.await())
 
-      publishTelemetry("allocation", prisonId, compareResults)
+      publishTelemetry("allocation", prisonId, compareResults, ignoreDifferentPrisons = false)
     }
   } catch (e: Exception) {
     log.error("Allocation reconciliation report failed for prison $prisonId", e)
@@ -77,7 +77,7 @@ class ActivitiesReconService(
       val dpsBookingCounts = async { activitiesApiService.getSuspendedAllocationReconciliation(prisonId) }
       val compareResults = compareBookingCounts(nomisBookingCounts.await(), dpsBookingCounts.await())
 
-      publishTelemetry("suspended-allocation", prisonId, compareResults, ignoreDifferentPrisons = false)
+      publishTelemetry("suspended-allocation", prisonId, compareResults)
     }
   } catch (e: Exception) {
     log.error("Suspended allocation reconciliation report failed for prison $prisonId", e)


### PR DESCRIPTION
We've found that reconciling suspended allocations where the prisoner has been transferred doesn't work out very well as the new prison often ends the allocation in NOMIS, but in practical terms this causes no issues. So now we don't want these to appear on the reconciliation.

On the other hand, we've been ignoring active allocations where the prisoner has been transferred, but again this isn't working out very well because if DPS doesn't end or suspend the allocation then it appears on the DPS prisoner schedule at the new prison which has been confusing staff. So now we do want these to appear on the reconciliation.

I'm starting to wonder if it's time to rewrite the allocation reconciliation. Much has changed in DPS since it was written such as various ways to suspend an allocation and planned future de-allocations. So we'll see how this goes, with a view to a new approach if it goes badly.