### PR TITLE
SDIT-2771 Ignore person name case in reconciliation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonReconciliationService.kt
@@ -416,8 +416,8 @@ class ContactPersonReconciliationService(
   }
   private fun PrisonerContactSummary.asSummary() = ContactSummary(
     contactId = this.contactId,
-    firstName = this.firstName,
-    lastName = this.lastName,
+    firstName = this.firstName.uppercase(),
+    lastName = this.lastName.uppercase(),
     relationshipCode = this.relationshipToPrisonerCode,
     contactType = this.relationshipTypeCode,
     emergencyContact = this.isEmergencyContact,
@@ -428,8 +428,8 @@ class ContactPersonReconciliationService(
 
   private fun PrisonerContact.asSummary() = ContactSummary(
     contactId = this.person.personId,
-    firstName = this.person.firstName,
-    lastName = this.person.lastName,
+    firstName = this.person.firstName.uppercase(),
+    lastName = this.person.lastName.uppercase(),
     relationshipCode = this.relationshipType.code,
     contactType = this.contactType.code,
     emergencyContact = this.emergencyContact,
@@ -440,8 +440,8 @@ class ContactPersonReconciliationService(
 
   private fun ContactPerson.asSummary() = PersonSummary(
     personId = this.personId,
-    firstName = this.firstName,
-    lastName = this.lastName,
+    firstName = this.firstName.uppercase(),
+    lastName = this.lastName.uppercase(),
     dateOfBirth = this.dateOfBirth?.takeIf { it.validDateOfBirth() },
     addressCount = this.addresses.size,
     phoneNumbers = this.phoneNumbers.map { it.number }.toSortedSet(),
@@ -454,8 +454,8 @@ class ContactPersonReconciliationService(
   )
   private fun SyncContactReconcile.asSummary() = PersonSummary(
     personId = this.contactId,
-    firstName = this.firstName,
-    lastName = this.lastName,
+    firstName = this.firstName.uppercase(),
+    lastName = this.lastName.uppercase(),
     dateOfBirth = this.dateOfBirth?.takeIf { it.validDateOfBirth() },
     addressCount = this.addresses.size,
     phoneNumbers = this.phones.map { it.phoneNumber }.toSortedSet(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonReconciliationServiceTest.kt
@@ -132,6 +132,34 @@ internal class ContactPersonReconciliationServiceTest {
     }
 
     @Nested
+    inner class WhenPrisonerHasSameContactsButWithDifferentCase {
+      @BeforeEach
+      fun beforeEach() {
+        stubContact(
+          dpsContact = prisonerContactSummary().copy(
+            contactId = 99,
+            firstName = "Jane",
+            lastName = "Smith",
+          ),
+          nomisContact = prisonerContact().copy(
+            person = ContactForPerson(
+              personId = 99,
+              firstName = "JANE",
+              lastName = "SMITH",
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `will not report a mismatch`() = runTest {
+        assertThat(
+          service.checkPrisonerContactsMatch(prisonerId),
+        ).isNull()
+      }
+    }
+
+    @Nested
     inner class WhenPrisonerHasSameDuplicateContactsButInDifferentOrder {
       @BeforeEach
       fun beforeEach() {
@@ -831,6 +859,29 @@ internal class ContactPersonReconciliationServiceTest {
           ),
           isNull(),
         )
+      }
+    }
+
+    @Nested
+    inner class WhenNamesHaveDifferentCase {
+
+      @BeforeEach
+      fun setUp() {
+        stubPersonContact(
+          nomisPerson.copy(
+            firstName = "KWEKU",
+            lastName = "KOFI",
+          ),
+          dpsContact.copy(
+            firstName = "Kweku",
+            lastName = "Kofi",
+          ),
+        )
+      }
+
+      @Test
+      fun `will not report a mismatch`() = runTest {
+        assertThat(service.checkPersonContactMatch(personId)).isNull()
       }
     }
 


### PR DESCRIPTION
DPS allows lower case in names, NOMIS is always converted to upper case