### PR TITLE
SDIT-2776 Purge the activities DLQ in preprod before the retryDLQ job runs

### DIFF
--- a/helm_deploy/hmpps-prisoner-to-nomis-update/templates/activities-purge-dlq-cronjob.yaml
+++ b/helm_deploy/hmpps-prisoner-to-nomis-update/templates/activities-purge-dlq-cronjob.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "app.fullname" . }}-activities-purge-dlq
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  schedule: "9-59/10 * * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      # Tidy up all jobs after 4 days
+      ttlSecondsAfterFinished: 345600
+      suspend: {{ .Values.cron.activitiesPurgeDlqSuspend }}
+      template:
+        spec:
+          containers:
+            - name: housekeeping
+              image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              args:
+                - /bin/sh
+                - -c
+                - curl --retry 2 -XPUT http://hmpps-prisoner-to-nomis-update/queue-admin/purge-queue/syscon-devs-preprod-hmpps_prisoner_to_nomis_activity_dlq
+              securityContext:
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+          restartPolicy: Never

--- a/helm_deploy/hmpps-prisoner-to-nomis-update/values.yaml
+++ b/helm_deploy/hmpps-prisoner-to-nomis-update/values.yaml
@@ -232,5 +232,6 @@ cron:
   suspendedAllocationReconReportSchedule: "35 7 * * *"
   attendanceReconReportSchedule: "5 1 * * *"
   activitiesTidyMappingsSuspend: true
+  activitiesPurgeDlqSuspend: true
   activitiesTidyMappingsSchedule: "15 7 * * 1-5"
   contactPersonProfileDetailsReportSchedule: "30 3 * * *"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -104,5 +104,6 @@ generic-prometheus-alerts:
 
 cron:
   activitiesTidyMappingsSuspend: false
+  activitiesPurgeDlqSuspend: false
   contactPersonProfileDetailsReportSchedule: "30 7 * * *"
 


### PR DESCRIPTION
In preprod the DPS activities database and NOMIS sync mappings databases are refreshed from prod several hours after the NOMIS preprod database is refreshed. This means data is out of sync and causes lots of events published by activities to fail. These failures are then retried every 10 minutes but always fail. As we rollout to more prisons this has turned into 10s of thousands of failing DLQ messages every 10 minutes. This is very noisy and achieves nothing.

A proper fix will involve refreshing all DPS databases at the same time and making sure all DPS systems are down until the refresh has completed. This will be complicated.

As a medium term workaround we will instead purge the DLQ before each retry takes place to stop the noise.