### PR TITLE
SDIT-2784 Update recall sentences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingDomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingDomainEventListener.kt
@@ -63,6 +63,8 @@ class CourtSentencingDomainEventListener(
         courtSentencingService.deleteSentenceTerm(message.fromJson())
       "recall.inserted" ->
         courtSentencingService.createRecallSentences(message.fromJson())
+      "recall.updated" ->
+        courtSentencingService.updateRecallSentences(message.fromJson())
       else -> log.info("Received a message I wasn't expecting: {}", eventType)
     }
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -176,7 +176,8 @@ hmpps.sqs:
         "sentence.inserted",
         "sentence.deleted",
         "sentence.updated",
-        "recall.inserted"
+        "recall.inserted",
+        "recall.updated"
         ]}
       dlqMaxReceiveCount: 3
       visibilityTimeout: 120


### PR DESCRIPTION
* Does the exact same as a create which is possibly ok, needs some testing
* Small workaround for the domain event not containing the sentence Ids