### PR TITLE
SDIT-2782 Recall updated/delete - status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingService.kt
@@ -884,7 +884,8 @@ class CourtSentencingService(
                 ),
                 sentenceCategory = sentence.dpsSentence.sentenceCategory,
                 sentenceCalcType = sentence.dpsSentence.sentenceCalcType,
-                active = sentence.dpsSentence.active,
+                // TODO - check with DPS if there is ever a scenario when this can be false
+                active = true,
               )
             },
             returnToCustody = recall.returnToCustodyDate?.takeIf { recall.recallType.isFixedTermRecall() }?. let {
@@ -944,7 +945,8 @@ class CourtSentencingService(
                   ),
                   sentenceCategory = sentence.dpsSentence.sentenceCategory,
                   sentenceCalcType = sentence.dpsSentence.sentenceCalcType,
-                  active = sentence.dpsSentence.active,
+                  // TODO - check with DPS if there is ever a scenario when this can be false
+                  active = true,
                 )
               },
               returnToCustody = recall.returnToCustodyDate?.takeIf { recall.recallType.isFixedTermRecall() }?. let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCasesToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCasesToNomisIntTest.kt
@@ -2970,7 +2970,8 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
             .withRequestBody(matchingJsonPath("sentences[1].sentenceId.sentenceSequence", equalTo("2")))
             .withRequestBody(matchingJsonPath("sentences[1].sentenceCategory", equalTo("2013")))
             .withRequestBody(matchingJsonPath("sentences[1].sentenceCalcType", equalTo("FTR_14")))
-            .withRequestBody(matchingJsonPath("sentences[1].active", equalTo("false")))
+            // always set to active despite original sentence status
+            .withRequestBody(matchingJsonPath("sentences[1].active", equalTo("true")))
             .withRequestBody(matchingJsonPath("returnToCustody.returnToCustodyDate", equalTo("2025-04-23")))
             .withRequestBody(matchingJsonPath("returnToCustody.recallLength", equalTo("14")))
             .withRequestBody(matchingJsonPath("returnToCustody.enteredByStaffUsername", equalTo("T.SMITH"))),


### PR DESCRIPTION
Always set the sentence status to active when updating a recall sentence. TODO - check with DPS if there is ever a scenario a recall sentence in NOMIS should be made inactive