### PR TITLE
SDIT-2776 POC to see if request header based authentication would work.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/config/ResourceServerConfiguration.kt
@@ -1,11 +1,64 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.security.authentication.ReactiveAuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.invoke
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.authentication.AuthenticationWebFilter
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
+import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import uk.gov.justice.hmpps.kotlin.auth.AuthAwareReactiveTokenConverter
+import uk.gov.justice.hmpps.kotlin.auth.HmppsReactiveResourceServerConfiguration
 import uk.gov.justice.hmpps.kotlin.auth.dsl.ResourceServerConfigurationCustomizer
 
 @Configuration
 class ResourceServerConfiguration {
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  @Bean
+  fun securityWebFilterChain(
+    http: ServerHttpSecurity,
+    cronjobAuthFilter: AuthenticationWebFilter,
+  ): SecurityWebFilterChain = http {
+    sessionManagement { SessionCreationPolicy.STATELESS }
+    csrf { disable() }
+    securityMatcher(PathPatternParserServerWebExchangeMatcher("/queue-admin/purge-queue/**"))
+    authorizeExchange {
+      authorize(anyExchange, authenticated)
+    }
+    oauth2ResourceServer { jwt { jwtAuthenticationConverter = AuthAwareReactiveTokenConverter() } }
+
+    addFilterAt(cronjobAuthFilter, SecurityWebFiltersOrder.AUTHENTICATION)
+  }
+
+  @Bean
+  fun cronjobAuthManager(): ReactiveAuthenticationManager = CronjobAuthenticationManager()
+
+  @Bean
+  fun cronjobAuthFilter(
+    cronjobAuthenticationManager: ReactiveAuthenticationManager,
+    @Value("\${cronjob.auth.secret}") cronjobAuthSecret: String,
+  ): AuthenticationWebFilter = AuthenticationWebFilter(cronjobAuthenticationManager).apply {
+    setServerAuthenticationConverter(CronjobAuthenticationConverter("X-Auth-CronJob", cronjobAuthSecret))
+  }
+
+  @Bean
+  fun securityFilterChain(
+    http: ServerHttpSecurity,
+    resourceServerCustomizer: ResourceServerConfigurationCustomizer,
+  ): SecurityWebFilterChain = HmppsReactiveResourceServerConfiguration().hmppsSecurityWebFilterChain(http, resourceServerCustomizer)
+
   @Bean
   fun resourceServerCustomizer() = ResourceServerConfigurationCustomizer {
     unauthorizedRequestPaths {
@@ -31,4 +84,26 @@ class ResourceServerConfiguration {
       )
     }
   }
+}
+
+class CronjobAuthenticationConverter(
+  private val headerName: String,
+  private val expectedSecret: String,
+) : ServerAuthenticationConverter {
+  override fun convert(exchange: ServerWebExchange): Mono<Authentication> = Mono.justOrEmpty(exchange.request.headers.getFirst(headerName))
+    .map { cronjobAuthSecret ->
+      if (cronjobAuthSecret == expectedSecret) {
+        UsernamePasswordAuthenticationToken.authenticated(
+          "cronJob",
+          cronjobAuthSecret,
+          mutableListOf(SimpleGrantedAuthority("ROLE_QUEUE_ADMIN")),
+        )
+      } else {
+        UsernamePasswordAuthenticationToken.unauthenticated("cronJob", cronjobAuthSecret)
+      }
+    }
+}
+
+class CronjobAuthenticationManager : ReactiveAuthenticationManager {
+  override fun authenticate(authentication: Authentication): Mono<Authentication> = Mono.just(authentication)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/PurgeDlqIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/PurgeDlqIntTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.integration.IntegrationTestBase
+import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
+
+class PurgeDlqIntTest(
+  @Autowired private val hmppsQueueProperties: HmppsSqsProperties,
+) : IntegrationTestBase() {
+
+  @Test
+  fun `access unauthorised when no authority`() {
+    webTestClient.put().uri("/queue-admin/purge-queue/${hmppsQueueProperties.queues["activity"]!!.dlqName}")
+      .exchange()
+      .expectStatus().isUnauthorized
+  }
+
+  @Test
+  fun `access unauthorised with invalid custom auth header`() {
+    webTestClient.put().uri("/queue-admin/purge-queue/${hmppsQueueProperties.queues["activity"]!!.dlqName}")
+      .headers { it.add("X-Auth-CronJob", "wrong-secret") }
+      .exchange()
+      .expectStatus().isUnauthorized
+  }
+
+  @Test
+  fun `access allowed with custom auth header`() {
+    webTestClient.put().uri("/queue-admin/purge-queue/${hmppsQueueProperties.queues["activity"]!!.dlqName}")
+      .headers { it.add("X-Auth-CronJob", "some-secret") }
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `access allowed with oauth token`() {
+    webTestClient.put().uri("/queue-admin/purge-queue/${hmppsQueueProperties.queues["activity"]!!.dlqName}")
+      .headers(setAuthorisation(roles = listOf("ROLE_QUEUE_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -338,3 +338,5 @@ reports:
     reconciliation:
       page-size: 10
 api.locations.timeout: 1s
+
+cronjob.auth.secret: some-secret


### PR DESCRIPTION
To complete the POC we'd need to get a secret added to the namespace terraform [e.g.](https://github.com/ministryofjustice/cloud-platform-environments/blob/978fc1d8a3ae4a40aac7aa23f9488d9ba476a1b2/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-delius-alfresco-dev/resources/amq.tf#L54) and check that the existing DLQ purge works.

To turn the POC into a full solution we'd need to add support for `ServerHttpSecurity.addFilterAt` to the HMPPS Kotlin lib and work out some way to configure a header value, header secret and list of roles for each additional header based security control that needs adding to a project.