### PR TITLE
SDIT-2801 Deleted adjustments do not throw exception

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsApiService.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyOrNullForNotFound
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyOrNullForStatus
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.sentencing.adjustments.model.AdjustmentDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.sentencing.adjustments.model.LegacyAdjustment
@@ -20,6 +21,12 @@ class SentencingAdjustmentsApiService(private val sentenceAdjustmentsApiWebClien
     .header("Content-Type", LEGACY_CONTENT_TYPE)
     .retrieve()
     .awaitBody()
+
+  suspend fun getAdjustmentOrNull(adjustmentId: String): LegacyAdjustment? = sentenceAdjustmentsApiWebClient.get()
+    .uri("/legacy/adjustments/{adjustmentId}", adjustmentId)
+    .header("Content-Type", LEGACY_CONTENT_TYPE)
+    .retrieve()
+    .awaitBodyOrNullForNotFound()
 
   suspend fun getAdjustments(offenderNo: String): List<AdjustmentDto>? = sentenceAdjustmentsApiWebClient.get()
     .uri("/adjustments?person={offenderNo}", offenderNo)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsApiServiceTest.kt
@@ -107,6 +107,31 @@ internal class SentencingAdjustmentsApiServiceTest {
   }
 
   @Nested
+  inner class GetAdjustmentOrNull {
+    @BeforeEach
+    internal fun setUp() {
+      sentencingAdjustmentsApi.stubAdjustmentGet(adjustmentId = "1234")
+    }
+
+    @Test
+    fun `should call api with OAuth2 token`(): Unit = runTest {
+      sentencingAdjustmentsApiService.getAdjustmentOrNull("1234")
+
+      sentencingAdjustmentsApi.verify(
+        getRequestedFor(urlEqualTo("/legacy/adjustments/1234"))
+          .withHeader("Authorization", WireMock.equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `when adjustment is not found it will return null`() = runTest {
+      sentencingAdjustmentsApi.stubAdjustmentGetWithError("1234", status = 404)
+
+      assertThat(sentencingAdjustmentsApiService.getAdjustmentOrNull("1234")).isNull()
+    }
+  }
+
+  @Nested
   @DisplayName("GET /adjustments?person={offenderNo}")
   inner class GetAdjustments {
     @BeforeEach


### PR DESCRIPTION
If an adjustment has been deleted, but we process an update event after the delete, just log telemetry rather than retrying with DLQ