### PR TITLE
SDIT-2814 Consume contacts-api.prisoner-contact.deleted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonDomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonDomainEventListener.kt
@@ -39,6 +39,7 @@ class ContactPersonDomainEventListener(
       "contacts-api.contact.updated" -> contactPersonService.contactUpdated(message.fromJson())
       "contacts-api.prisoner-contact.created" -> contactPersonService.prisonerContactCreated(message.fromJson())
       "contacts-api.prisoner-contact.updated" -> contactPersonService.prisonerContactUpdated(message.fromJson())
+      "contacts-api.prisoner-contact.deleted" -> contactPersonService.prisonerContactDeleted(message.fromJson())
       "contacts-api.contact-address.created" -> contactPersonService.contactAddressCreated(message.fromJson())
       "contacts-api.contact-address.updated" -> contactPersonService.contactAddressUpdated(message.fromJson())
       "contacts-api.contact-address.deleted" -> contactPersonService.contactAddressDeleted(message.fromJson())
@@ -104,6 +105,12 @@ data class PrisonerContactCreatedEvent(
   ContactIdReferencedEvent
 
 data class PrisonerContactUpdatedEvent(
+  override val additionalInformation: PrisonerContactAdditionalData,
+  override val personReference: ContactIdentifiers,
+) : SourcedContactPersonEvent,
+  ContactIdReferencedEvent
+
+data class PrisonerContactDeletedEvent(
   override val additionalInformation: PrisonerContactAdditionalData,
   override val personReference: ContactIdentifiers,
 ) : SourcedContactPersonEvent,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonService.kt
@@ -238,6 +238,22 @@ class ContactPersonService(
       telemetryClient.trackEvent("$entityName-update-ignored", telemetryMap)
     }
   }
+  suspend fun prisonerContactDeleted(event: PrisonerContactDeletedEvent) {
+    val entityName = CONTACT.entityName
+
+    val dpsPrisonerContactId = event.additionalInformation.prisonerContactId
+    val telemetryMap = mutableMapOf(
+      "dpsPrisonerContactId" to dpsPrisonerContactId.toString(),
+    )
+
+    if (event.didOriginateInDPS()) {
+      telemetryClient.trackEvent("$entityName-delete-unsupported", telemetryMap)
+      // DPS doesn't currently allow this - if it ever does we would need to support it
+      throw IllegalStateException("Should not be able delete prisoner contact from DPS - if this is happening this needs to be supported by sync")
+    } else {
+      telemetryClient.trackEvent("$entityName-delete-ignored", telemetryMap)
+    }
+  }
 
   suspend fun contactAddressCreated(event: ContactAddressCreatedEvent) {
     val entityName = CONTACT_ADDRESS.entityName

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/ContactPersonToNomisIntTest.kt
@@ -827,6 +827,50 @@ class ContactPersonToNomisIntTest : SqsIntegrationTestBase() {
   }
 
   @Nested
+  @DisplayName("contacts-api.prisoner-contact.deleted")
+  inner class PrisonerContactDeleted {
+
+    @Nested
+    @DisplayName("when NOMIS is the origin of a Contact delete")
+    inner class WhenNomisUpdated {
+
+      @BeforeEach
+      fun setUp() {
+        publishDeletePrisonerContactDomainEvent(prisonerContactId = "12345", source = "NOMIS")
+        waitForAnyProcessingToComplete()
+      }
+
+      @Test
+      fun `will send telemetry event showing the ignore`() {
+        verify(telemetryClient).trackEvent(
+          eq("contact-delete-ignored"),
+          any(),
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
+    @DisplayName("when DPS is the origin of a Prisoner Contact update")
+    inner class WhenDpsUpdated {
+      @BeforeEach
+      fun setUp() {
+        publishDeletePrisonerContactDomainEvent(prisonerContactId = "12345", source = "DPS")
+        waitForAnyProcessingToComplete()
+      }
+
+      @Test
+      fun `will send telemetry event showing the ignore`() {
+        verify(telemetryClient).trackEvent(
+          eq("contact-delete-unsupported"),
+          any(),
+          isNull(),
+        )
+      }
+    }
+  }
+
+  @Nested
   @DisplayName("contacts-api.contact-address.created")
   inner class ContactAddressCreated {
 
@@ -4354,6 +4398,11 @@ class ContactPersonToNomisIntTest : SqsIntegrationTestBase() {
   }
   private fun publishUpdatePrisonerContactDomainEvent(prisonerContactId: String, source: String = "DPS") {
     with("contacts-api.prisoner-contact.updated") {
+      publishDomainEvent(eventType = this, payload = prisonerContactMessagePayload(eventType = this, prisonerContactId = prisonerContactId, source = source))
+    }
+  }
+  private fun publishDeletePrisonerContactDomainEvent(prisonerContactId: String, source: String = "DPS") {
+    with("contacts-api.prisoner-contact.deleted") {
       publishDomainEvent(eventType = this, payload = prisonerContactMessagePayload(eventType = this, prisonerContactId = prisonerContactId, source = source))
     }
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -249,6 +249,7 @@ hmpps.sqs:
           "contacts-api.contact.updated",
           "contacts-api.prisoner-contact.created",
           "contacts-api.prisoner-contact.updated",
+          "contacts-api.prisoner-contact.deleted",
           "contacts-api.contact-address.created",
           "contacts-api.contact-address.updated",
           "contacts-api.contact-address.deleted",


### PR DESCRIPTION
Since DPS doesn't support this we just log the NOMIS equivalent that does allow this.

This would capture if this was every supported by throwing exception