### PR TITLE
SDIT-2982 Create court appearance now uses batch mappings endpoint

### DIFF
--- a/openapi-specs/nomis-mapping-service-api-docs.json
+++ b/openapi-specs/nomis-mapping-service-api-docs.json
@@ -7,7 +7,7 @@
       "name" : "HMPPS Digital Studio",
       "email" : "feedback@digital.justice.gov.uk"
     },
-    "version" : "2025-08-12.91.c9c75f9"
+    "version" : "2025-08-13.108.9341858"
   },
   "servers" : [ {
     "url" : "https://nomis-sync-prisoner-mapping.hmpps.service.justice.gov.uk",
@@ -426,6 +426,50 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/DuplicateMappingErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapping/court-sentencing/court-cases/replace" : {
+      "put" : {
+        "tags" : [ "court-sentencing-mapping-resource" ],
+        "summary" : "Replaces all court case hierarchical mappings maintaining the DPS id",
+        "description" : "Replaces all the mappings between nomis Court Case ID and DPS Court Case ID. Also maps child entities: Court appearances and charges. Where a mapping does not exist for the DPS id it will create one. Requires ROLE_NOMIS_COURT_SENTENCING",
+        "operationId" : "replaceOrCreateMappingByDpsId",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CourtCaseBatchMappingDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Mapping created or replaced",
+            "content" : { }
+          },
+          "401" : {
+            "description" : "Unauthorized to access this endpoint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Access forbidden for this endpoint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1583,6 +1627,60 @@
         "responses" : {
           "201" : {
             "description" : "Mapping created",
+            "content" : { }
+          },
+          "401" : {
+            "description" : "Unauthorized to access this endpoint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Access forbidden for this endpoint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Indicates a duplicate mapping has been rejected. If Error code = 1409 the body will return a DuplicateErrorResponse",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DuplicateMappingErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapping/temporary-absence/migrate" : {
+      "post" : {
+        "tags" : [ "temporary-absence-resource" ],
+        "summary" : "Creates all mappings for prisoner temporary absences which are all migrated at the same time",
+        "description" : "Creates mappings for prisoner temporary absences including movement applications, outside movements, scheduled movements and movements. Requires ROLE_NOMIS_MOVEMENTS",
+        "operationId" : "createMappings_2",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CorporateMappingsDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Mappings created",
             "content" : { }
           },
           "401" : {
@@ -2802,7 +2900,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CourtCaseMigrationMappingDto"
+                "$ref" : "#/components/schemas/CourtCaseBatchMappingDto"
               }
             }
           },
@@ -3294,7 +3392,7 @@
         "tags" : [ "corporate-mapping-resource" ],
         "summary" : "Creates a tree of corporate mappings typically for a migration",
         "description" : "Creates a tree of corporate mappings typically for a migration between NOMIS ids and dps ids. Requires ROLE_NOMIS_CONTACTPERSONS",
-        "operationId" : "createMappings_2",
+        "operationId" : "createMappings_3",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3510,7 +3608,7 @@
         "tags" : [ "core-person-mapping-resource" ],
         "summary" : "Creates a tree of core person mappings typically for a migration",
         "description" : "Creates a tree of core person mappings typically for a migration between NOMIS ids and cpr ids. Requires ROLE_NOMIS_CORE_PERSON",
-        "operationId" : "createMappings_3",
+        "operationId" : "createMappings_4",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4082,7 +4180,7 @@
         "tags" : [ "contact-person-mapping-resource" ],
         "summary" : "Creates a tree of contact person mappings typically for a migration",
         "description" : "Creates a tree of contact person mappings typically for a migration between NOMIS ids and dps ids. Requires ROLE_NOMIS_CONTACTPERSONS",
-        "operationId" : "createMappings_4",
+        "operationId" : "createMappings_5",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4519,7 +4617,7 @@
         "tags" : [ "case-notes-mapping-resource" ],
         "summary" : "Creates a batch of new casenote mappings",
         "description" : "Creates a mapping between a batch of nomis casenote ids and dps casenote id. Requires ROLE_NOMIS_CASENOTES",
-        "operationId" : "createMappings_5",
+        "operationId" : "createMappings_6",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4759,7 +4857,7 @@
         "tags" : [ "alerts-mapping-resource" ],
         "summary" : "Creates a batch of new alert mappings",
         "description" : "Creates a mapping between a batch of nomis alert ids and dps alert id. Requires ROLE_NOMIS_ALERTS",
-        "operationId" : "createMappings_6",
+        "operationId" : "createMappings_7",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -16662,6 +16760,230 @@
         },
         "required" : [ "nomisCourtChargeId" ]
       },
+      "CourtAppearanceMappingDto" : {
+        "type" : "object",
+        "description" : "Court appearance mapping",
+        "properties" : {
+          "nomisCourtAppearanceId" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "NOMIS court appearance id",
+            "example" : 123456
+          },
+          "dpsCourtAppearanceId" : {
+            "type" : "string",
+            "description" : "DPS court appearance id",
+            "example" : 123456
+          },
+          "label" : {
+            "type" : "string",
+            "description" : "Label (a timestamp for migrated ids)",
+            "maxLength" : 20,
+            "minLength" : 0
+          },
+          "mappingType" : {
+            "type" : "string",
+            "default" : "DPS_CREATED",
+            "description" : "Mapping type",
+            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
+          },
+          "whenCreated" : {
+            "type" : "string",
+            "description" : "Date-time the mapping was created",
+            "example" : "2021-07-05T10:35:17",
+            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+          }
+        },
+        "required" : [ "dpsCourtAppearanceId", "nomisCourtAppearanceId" ]
+      },
+      "CourtCaseBatchMappingDto" : {
+        "type" : "object",
+        "description" : "Court cases mapping including child entity mapping",
+        "properties" : {
+          "courtCases" : {
+            "type" : "array",
+            "description" : "Mappings",
+            "items" : {
+              "$ref" : "#/components/schemas/CourtCaseMappingDto"
+            }
+          },
+          "courtAppearances" : {
+            "type" : "array",
+            "description" : "Court Appearance mappings",
+            "items" : {
+              "$ref" : "#/components/schemas/CourtAppearanceMappingDto"
+            }
+          },
+          "courtCharges" : {
+            "type" : "array",
+            "description" : "Court Charge mappings",
+            "items" : {
+              "$ref" : "#/components/schemas/CourtChargeMappingDto"
+            }
+          },
+          "sentences" : {
+            "type" : "array",
+            "description" : "Sentence mappings",
+            "items" : {
+              "$ref" : "#/components/schemas/SentenceMappingDto"
+            }
+          },
+          "sentenceTerms" : {
+            "type" : "array",
+            "description" : "Sentence term mappings",
+            "items" : {
+              "$ref" : "#/components/schemas/SentenceTermMappingDto"
+            }
+          },
+          "label" : {
+            "type" : "string",
+            "description" : "Label (a timestamp for migrated ids)"
+          },
+          "mappingType" : {
+            "type" : "string",
+            "description" : "Mapping type",
+            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
+          },
+          "whenCreated" : {
+            "type" : "string",
+            "description" : "Date time the mapping was created",
+            "example" : "2021-07-05T10:35:17",
+            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+          }
+        },
+        "required" : [ "courtAppearances", "courtCases", "courtCharges", "mappingType", "sentenceTerms", "sentences" ]
+      },
+      "CourtCaseMappingDto" : {
+        "type" : "object",
+        "description" : "Court case mapping",
+        "properties" : {
+          "nomisCourtCaseId" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "NOMIS court case id",
+            "example" : 123456
+          },
+          "dpsCourtCaseId" : {
+            "type" : "string",
+            "description" : "DPS court case id",
+            "example" : 123456
+          },
+          "offenderNo" : {
+            "type" : "string",
+            "description" : "NOMIS offender no/nomisId",
+            "example" : "AA12345"
+          },
+          "label" : {
+            "type" : "string",
+            "description" : "Label (a timestamp for migrated ids)",
+            "maxLength" : 20,
+            "minLength" : 0
+          },
+          "mappingType" : {
+            "type" : "string",
+            "default" : "DPS_CREATED",
+            "description" : "Mapping type",
+            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
+          },
+          "whenCreated" : {
+            "type" : "string",
+            "description" : "Date-time the mapping was created",
+            "example" : "2021-07-05T10:35:17",
+            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+          }
+        },
+        "required" : [ "dpsCourtCaseId", "nomisCourtCaseId" ]
+      },
+      "SentenceMappingDto" : {
+        "type" : "object",
+        "description" : "Sentence mapping",
+        "properties" : {
+          "nomisBookingId" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "NOMIS booking id",
+            "example" : 123456
+          },
+          "nomisSentenceSequence" : {
+            "type" : "integer",
+            "format" : "int32",
+            "description" : "NOMIS sentence sequence",
+            "example" : 4
+          },
+          "dpsSentenceId" : {
+            "type" : "string",
+            "description" : "DPS sentence id",
+            "example" : 123456
+          },
+          "label" : {
+            "type" : "string",
+            "description" : "Label (a timestamp for migrated ids)",
+            "maxLength" : 20,
+            "minLength" : 0
+          },
+          "mappingType" : {
+            "type" : "string",
+            "default" : "DPS_CREATED",
+            "description" : "Mapping type",
+            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
+          },
+          "whenCreated" : {
+            "type" : "string",
+            "description" : "Date-time the mapping was created",
+            "example" : "2021-07-05T10:35:17",
+            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+          }
+        },
+        "required" : [ "dpsSentenceId", "nomisBookingId", "nomisSentenceSequence" ]
+      },
+      "SentenceTermMappingDto" : {
+        "type" : "object",
+        "description" : "Sentence term mapping",
+        "properties" : {
+          "nomisBookingId" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "NOMIS booking id",
+            "example" : 123456
+          },
+          "nomisSentenceSequence" : {
+            "type" : "integer",
+            "format" : "int32",
+            "description" : "NOMIS sentence sequence",
+            "example" : 4
+          },
+          "nomisTermSequence" : {
+            "type" : "integer",
+            "format" : "int32",
+            "description" : "NOMIS term sequence",
+            "example" : 4
+          },
+          "dpsTermId" : {
+            "type" : "string",
+            "description" : "DPS sentence id",
+            "example" : 123456
+          },
+          "label" : {
+            "type" : "string",
+            "description" : "Label (a timestamp for migrated ids)",
+            "maxLength" : 20,
+            "minLength" : 0
+          },
+          "mappingType" : {
+            "type" : "string",
+            "default" : "DPS_CREATED",
+            "description" : "Mapping type",
+            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
+          },
+          "whenCreated" : {
+            "type" : "string",
+            "description" : "Date-time the mapping was created",
+            "example" : "2021-07-05T10:35:17",
+            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+          }
+        },
+        "required" : [ "dpsTermId", "nomisBookingId", "nomisSentenceSequence", "nomisTermSequence" ]
+      },
       "ContactPersonProfileDetailsMigrationMappingDto" : {
         "type" : "object",
         "description" : "Mappings for a Contact Person Profile Details Migration",
@@ -17077,6 +17399,83 @@
           }
         },
         "required" : [ "dpsId", "mappingType", "nomisVisitBalanceId" ]
+      },
+      "CorporateMappingIdDto" : {
+        "type" : "object",
+        "description" : "NOMIS to DPS simple mapping IDs",
+        "properties" : {
+          "dpsId" : {
+            "type" : "string",
+            "description" : "DPS id"
+          },
+          "nomisId" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "NOMIS id"
+          }
+        },
+        "required" : [ "dpsId", "nomisId" ]
+      },
+      "CorporateMappingsDto" : {
+        "type" : "object",
+        "description" : "Mappings for a Corporate and there associated child entities",
+        "properties" : {
+          "label" : {
+            "type" : "string",
+            "description" : "Label (a timestamp for migrated ids)"
+          },
+          "mappingType" : {
+            "type" : "string",
+            "description" : "Mapping type",
+            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
+          },
+          "whenCreated" : {
+            "type" : "string",
+            "description" : "Date time the mapping was created",
+            "example" : "2021-07-05T10:35:17",
+            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+          },
+          "corporateMapping" : {
+            "$ref" : "#/components/schemas/CorporateMappingIdDto",
+            "description" : "Corporate mapping"
+          },
+          "corporateAddressMapping" : {
+            "type" : "array",
+            "description" : "Corporate address mapping",
+            "items" : {
+              "$ref" : "#/components/schemas/CorporateMappingIdDto"
+            }
+          },
+          "corporateAddressPhoneMapping" : {
+            "type" : "array",
+            "description" : "Corporate address phone mapping",
+            "items" : {
+              "$ref" : "#/components/schemas/CorporateMappingIdDto"
+            }
+          },
+          "corporatePhoneMapping" : {
+            "type" : "array",
+            "description" : "Corporate phone mapping",
+            "items" : {
+              "$ref" : "#/components/schemas/CorporateMappingIdDto"
+            }
+          },
+          "corporateEmailMapping" : {
+            "type" : "array",
+            "description" : "Corporate email mapping",
+            "items" : {
+              "$ref" : "#/components/schemas/CorporateMappingIdDto"
+            }
+          },
+          "corporateWebMapping" : {
+            "type" : "array",
+            "description" : "Corporate web mapping",
+            "items" : {
+              "$ref" : "#/components/schemas/CorporateMappingIdDto"
+            }
+          }
+        },
+        "required" : [ "corporateAddressMapping", "corporateAddressPhoneMapping", "corporateEmailMapping", "corporateMapping", "corporatePhoneMapping", "corporateWebMapping", "mappingType" ]
       },
       "SentencingAdjustmentMappingDto" : {
         "type" : "object",
@@ -17690,48 +18089,6 @@
         },
         "required" : [ "dpsCSIPId", "id", "isNew", "mappingType", "new", "nomisCSIPId" ]
       },
-      "SentenceMappingDto" : {
-        "type" : "object",
-        "description" : "Sentence mapping",
-        "properties" : {
-          "nomisBookingId" : {
-            "type" : "integer",
-            "format" : "int64",
-            "description" : "NOMIS booking id",
-            "example" : 123456
-          },
-          "nomisSentenceSequence" : {
-            "type" : "integer",
-            "format" : "int32",
-            "description" : "NOMIS sentence sequence",
-            "example" : 4
-          },
-          "dpsSentenceId" : {
-            "type" : "string",
-            "description" : "DPS sentence id",
-            "example" : 123456
-          },
-          "label" : {
-            "type" : "string",
-            "description" : "Label (a timestamp for migrated ids)",
-            "maxLength" : 20,
-            "minLength" : 0
-          },
-          "mappingType" : {
-            "type" : "string",
-            "default" : "DPS_CREATED",
-            "description" : "Mapping type",
-            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
-          },
-          "whenCreated" : {
-            "type" : "string",
-            "description" : "Date-time the mapping was created",
-            "example" : "2021-07-05T10:35:17",
-            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
-          }
-        },
-        "required" : [ "dpsSentenceId", "nomisBookingId", "nomisSentenceSequence" ]
-      },
       "NomisSentenceId" : {
         "type" : "object",
         "description" : "NOMIS Sentence ID",
@@ -17789,54 +18146,6 @@
         },
         "required" : [ "dpsSentenceId", "id", "isNew", "mappingType", "new", "nomisBookingId", "nomisSentenceSequence" ]
       },
-      "SentenceTermMappingDto" : {
-        "type" : "object",
-        "description" : "Sentence term mapping",
-        "properties" : {
-          "nomisBookingId" : {
-            "type" : "integer",
-            "format" : "int64",
-            "description" : "NOMIS booking id",
-            "example" : 123456
-          },
-          "nomisSentenceSequence" : {
-            "type" : "integer",
-            "format" : "int32",
-            "description" : "NOMIS sentence sequence",
-            "example" : 4
-          },
-          "nomisTermSequence" : {
-            "type" : "integer",
-            "format" : "int32",
-            "description" : "NOMIS term sequence",
-            "example" : 4
-          },
-          "dpsTermId" : {
-            "type" : "string",
-            "description" : "DPS sentence id",
-            "example" : 123456
-          },
-          "label" : {
-            "type" : "string",
-            "description" : "Label (a timestamp for migrated ids)",
-            "maxLength" : 20,
-            "minLength" : 0
-          },
-          "mappingType" : {
-            "type" : "string",
-            "default" : "DPS_CREATED",
-            "description" : "Mapping type",
-            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
-          },
-          "whenCreated" : {
-            "type" : "string",
-            "description" : "Date-time the mapping was created",
-            "example" : "2021-07-05T10:35:17",
-            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
-          }
-        },
-        "required" : [ "dpsTermId", "nomisBookingId", "nomisSentenceSequence", "nomisTermSequence" ]
-      },
       "SentenceTermMapping" : {
         "type" : "object",
         "properties" : {
@@ -17878,140 +18187,6 @@
           }
         },
         "required" : [ "dpsTermId", "id", "isNew", "mappingType", "new", "nomisBookingId", "nomisSentenceSequence", "nomisTermSequence" ]
-      },
-      "CourtAppearanceMappingDto" : {
-        "type" : "object",
-        "description" : "Court appearance mapping",
-        "properties" : {
-          "nomisCourtAppearanceId" : {
-            "type" : "integer",
-            "format" : "int64",
-            "description" : "NOMIS court appearance id",
-            "example" : 123456
-          },
-          "dpsCourtAppearanceId" : {
-            "type" : "string",
-            "description" : "DPS court appearance id",
-            "example" : 123456
-          },
-          "label" : {
-            "type" : "string",
-            "description" : "Label (a timestamp for migrated ids)",
-            "maxLength" : 20,
-            "minLength" : 0
-          },
-          "mappingType" : {
-            "type" : "string",
-            "default" : "DPS_CREATED",
-            "description" : "Mapping type",
-            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
-          },
-          "whenCreated" : {
-            "type" : "string",
-            "description" : "Date-time the mapping was created",
-            "example" : "2021-07-05T10:35:17",
-            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
-          }
-        },
-        "required" : [ "dpsCourtAppearanceId", "nomisCourtAppearanceId" ]
-      },
-      "CourtCaseMappingDto" : {
-        "type" : "object",
-        "description" : "Court case mapping",
-        "properties" : {
-          "nomisCourtCaseId" : {
-            "type" : "integer",
-            "format" : "int64",
-            "description" : "NOMIS court case id",
-            "example" : 123456
-          },
-          "dpsCourtCaseId" : {
-            "type" : "string",
-            "description" : "DPS court case id",
-            "example" : 123456
-          },
-          "offenderNo" : {
-            "type" : "string",
-            "description" : "NOMIS offender no/nomisId",
-            "example" : "AA12345"
-          },
-          "label" : {
-            "type" : "string",
-            "description" : "Label (a timestamp for migrated ids)",
-            "maxLength" : 20,
-            "minLength" : 0
-          },
-          "mappingType" : {
-            "type" : "string",
-            "default" : "DPS_CREATED",
-            "description" : "Mapping type",
-            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
-          },
-          "whenCreated" : {
-            "type" : "string",
-            "description" : "Date-time the mapping was created",
-            "example" : "2021-07-05T10:35:17",
-            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
-          }
-        },
-        "required" : [ "dpsCourtCaseId", "nomisCourtCaseId" ]
-      },
-      "CourtCaseMigrationMappingDto" : {
-        "type" : "object",
-        "description" : "Court cases mapping including child entity mapping",
-        "properties" : {
-          "courtCases" : {
-            "type" : "array",
-            "description" : "Mappings",
-            "items" : {
-              "$ref" : "#/components/schemas/CourtCaseMappingDto"
-            }
-          },
-          "courtAppearances" : {
-            "type" : "array",
-            "description" : "Court Appearance mappings",
-            "items" : {
-              "$ref" : "#/components/schemas/CourtAppearanceMappingDto"
-            }
-          },
-          "courtCharges" : {
-            "type" : "array",
-            "description" : "Court Charge mappings",
-            "items" : {
-              "$ref" : "#/components/schemas/CourtChargeMappingDto"
-            }
-          },
-          "sentences" : {
-            "type" : "array",
-            "description" : "Sentence mappings",
-            "items" : {
-              "$ref" : "#/components/schemas/SentenceMappingDto"
-            }
-          },
-          "sentenceTerms" : {
-            "type" : "array",
-            "description" : "Sentence term mappings",
-            "items" : {
-              "$ref" : "#/components/schemas/SentenceTermMappingDto"
-            }
-          },
-          "label" : {
-            "type" : "string",
-            "description" : "Label (a timestamp for migrated ids)"
-          },
-          "mappingType" : {
-            "type" : "string",
-            "description" : "Mapping type",
-            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
-          },
-          "whenCreated" : {
-            "type" : "string",
-            "description" : "Date time the mapping was created",
-            "example" : "2021-07-05T10:35:17",
-            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
-          }
-        },
-        "required" : [ "courtAppearances", "courtCases", "courtCharges", "mappingType", "sentenceTerms", "sentences" ]
       },
       "CourtChargeMapping" : {
         "type" : "object",
@@ -18202,83 +18377,6 @@
           }
         },
         "required" : [ "dpsId", "mappingType", "nomisId" ]
-      },
-      "CorporateMappingIdDto" : {
-        "type" : "object",
-        "description" : "NOMIS to DPS simple mapping IDs",
-        "properties" : {
-          "dpsId" : {
-            "type" : "string",
-            "description" : "DPS id"
-          },
-          "nomisId" : {
-            "type" : "integer",
-            "format" : "int64",
-            "description" : "NOMIS id"
-          }
-        },
-        "required" : [ "dpsId", "nomisId" ]
-      },
-      "CorporateMappingsDto" : {
-        "type" : "object",
-        "description" : "Mappings for a Corporate and there associated child entities",
-        "properties" : {
-          "label" : {
-            "type" : "string",
-            "description" : "Label (a timestamp for migrated ids)"
-          },
-          "mappingType" : {
-            "type" : "string",
-            "description" : "Mapping type",
-            "enum" : [ "MIGRATED", "DPS_CREATED", "NOMIS_CREATED" ]
-          },
-          "whenCreated" : {
-            "type" : "string",
-            "description" : "Date time the mapping was created",
-            "example" : "2021-07-05T10:35:17",
-            "pattern" : "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
-          },
-          "corporateMapping" : {
-            "$ref" : "#/components/schemas/CorporateMappingIdDto",
-            "description" : "Corporate mapping"
-          },
-          "corporateAddressMapping" : {
-            "type" : "array",
-            "description" : "Corporate address mapping",
-            "items" : {
-              "$ref" : "#/components/schemas/CorporateMappingIdDto"
-            }
-          },
-          "corporateAddressPhoneMapping" : {
-            "type" : "array",
-            "description" : "Corporate address phone mapping",
-            "items" : {
-              "$ref" : "#/components/schemas/CorporateMappingIdDto"
-            }
-          },
-          "corporatePhoneMapping" : {
-            "type" : "array",
-            "description" : "Corporate phone mapping",
-            "items" : {
-              "$ref" : "#/components/schemas/CorporateMappingIdDto"
-            }
-          },
-          "corporateEmailMapping" : {
-            "type" : "array",
-            "description" : "Corporate email mapping",
-            "items" : {
-              "$ref" : "#/components/schemas/CorporateMappingIdDto"
-            }
-          },
-          "corporateWebMapping" : {
-            "type" : "array",
-            "description" : "Corporate web mapping",
-            "items" : {
-              "$ref" : "#/components/schemas/CorporateMappingIdDto"
-            }
-          }
-        },
-        "required" : [ "corporateAddressMapping", "corporateAddressPhoneMapping", "corporateEmailMapping", "corporateMapping", "corporatePhoneMapping", "corporateWebMapping", "mappingType" ]
       },
       "CorePersonMappingIdDto" : {
         "type" : "object",

--- a/openapi-specs/nomis-prisoner-api-docs.json
+++ b/openapi-specs/nomis-prisoner-api-docs.json
@@ -7,7 +7,7 @@
       "name" : "HMPPS Digital Studio",
       "email" : "feedback@digital.justice.gov.uk"
     },
-    "version" : "2025-08-12.391.cedb0b0"
+    "version" : "2025-08-13.397.c0d7c73"
   },
   "servers" : [ {
     "url" : "https://nomis-prisoner-api-dev.prison.service.justice.gov.uk",
@@ -22311,6 +22311,342 @@
         },
         "required" : [ "courtId", "legalCaseType", "startDate", "status" ]
       },
+      "CaseIdentifierResponse" : {
+        "type" : "object",
+        "description" : "Case related reference",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "description" : "The type of case identifier",
+            "example" : "CASE/INFO#"
+          },
+          "reference" : {
+            "type" : "string",
+            "description" : "The value of the case identifier",
+            "example" : "asd/123"
+          },
+          "createDateTime" : {
+            "type" : "string",
+            "format" : "date-time",
+            "description" : "The time the case identifier was created",
+            "example" : "2020-07-17T12:34:56"
+          },
+          "modifiedDateTime" : {
+            "type" : "string",
+            "format" : "date-time",
+            "description" : "The time the case identifier was last changed",
+            "example" : "2021-07-16T12:34:56"
+          },
+          "auditModuleName" : {
+            "type" : "string",
+            "description" : "The name of the module that last changed it, indicates if this was NOMIS or the synchronisation service",
+            "example" : "DPS_SYNCHRONISATION"
+          }
+        },
+        "required" : [ "createDateTime", "reference", "type" ]
+      },
+      "ClonedCourtCaseResponse" : {
+        "type" : "object",
+        "description" : "Court Cases created due to a booking clone operation",
+        "properties" : {
+          "courtCase" : {
+            "$ref" : "#/components/schemas/CourtCaseResponse",
+            "description" : "Created court case and children"
+          },
+          "sourceCourtCase" : {
+            "$ref" : "#/components/schemas/CourtCaseResponse",
+            "description" : "Source court case and children that the cases were cloned from"
+          }
+        },
+        "required" : [ "courtCase", "sourceCourtCase" ]
+      },
+      "CourtCaseResponse" : {
+        "type" : "object",
+        "description" : "Court Case",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "offenderNo" : {
+            "type" : "string"
+          },
+          "bookingId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "primaryCaseInfoNumber" : {
+            "type" : "string"
+          },
+          "caseSequence" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "caseStatus" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "legalCaseType" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "beginDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "courtId" : {
+            "type" : "string"
+          },
+          "combinedCaseId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "sourceCombinedCaseIds" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "statusUpdateStaffId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "statusUpdateDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "statusUpdateComment" : {
+            "type" : "string"
+          },
+          "statusUpdateReason" : {
+            "type" : "string"
+          },
+          "lidsCaseId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "lidsCombinedCaseId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "createdDateTime" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "createdByUsername" : {
+            "type" : "string"
+          },
+          "courtEvents" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CourtEventResponse"
+            }
+          },
+          "offenderCharges" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OffenderChargeResponse"
+            }
+          },
+          "caseInfoNumbers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CaseIdentifierResponse"
+            }
+          },
+          "sentences" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SentenceResponse"
+            }
+          }
+        },
+        "required" : [ "bookingId", "caseInfoNumbers", "caseSequence", "caseStatus", "courtEvents", "courtId", "createdByUsername", "createdDateTime", "id", "legalCaseType", "offenderCharges", "offenderNo", "sentences", "sourceCombinedCaseIds" ]
+      },
+      "CourtEventChargeResponse" : {
+        "type" : "object",
+        "description" : "Court Event Charge",
+        "properties" : {
+          "eventId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "offenderCharge" : {
+            "$ref" : "#/components/schemas/OffenderChargeResponse"
+          },
+          "offencesCount" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "offenceDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "offenceEndDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "plea" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "propertyValue" : {
+            "type" : "number"
+          },
+          "totalPropertyValue" : {
+            "type" : "number"
+          },
+          "cjitCode1" : {
+            "type" : "string"
+          },
+          "cjitCode2" : {
+            "type" : "string"
+          },
+          "cjitCode3" : {
+            "type" : "string"
+          },
+          "resultCode1" : {
+            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
+          },
+          "resultCode2" : {
+            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
+          },
+          "mostSeriousFlag" : {
+            "type" : "boolean"
+          },
+          "linkedCaseDetails" : {
+            "$ref" : "#/components/schemas/LinkedCaseChargeDetails"
+          }
+        },
+        "required" : [ "eventId", "mostSeriousFlag", "offenderCharge" ]
+      },
+      "CourtEventResponse" : {
+        "type" : "object",
+        "description" : "Court Event",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "caseId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "offenderNo" : {
+            "type" : "string"
+          },
+          "eventDateTime" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "courtEventType" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "eventStatus" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "directionCode" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "judgeName" : {
+            "type" : "string"
+          },
+          "courtId" : {
+            "type" : "string"
+          },
+          "outcomeReasonCode" : {
+            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
+          },
+          "commentText" : {
+            "type" : "string"
+          },
+          "orderRequestedFlag" : {
+            "type" : "boolean"
+          },
+          "holdFlag" : {
+            "type" : "boolean"
+          },
+          "nextEventRequestFlag" : {
+            "type" : "boolean"
+          },
+          "nextEventDateTime" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "createdDateTime" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "createdByUsername" : {
+            "type" : "string"
+          },
+          "courtEventCharges" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CourtEventChargeResponse"
+            }
+          },
+          "courtOrders" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CourtOrderResponse"
+            }
+          }
+        },
+        "required" : [ "courtEventCharges", "courtEventType", "courtId", "courtOrders", "createdByUsername", "createdDateTime", "eventDateTime", "eventStatus", "id", "offenderNo" ]
+      },
+      "CourtOrderResponse" : {
+        "type" : "object",
+        "description" : "Court Order",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "eventId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "courtDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "issuingCourt" : {
+            "type" : "string"
+          },
+          "courtInfoId" : {
+            "type" : "string"
+          },
+          "orderType" : {
+            "type" : "string"
+          },
+          "orderStatus" : {
+            "type" : "string"
+          },
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "requestDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "seriousnessLevel" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "commentText" : {
+            "type" : "string"
+          },
+          "nonReportFlag" : {
+            "type" : "boolean"
+          },
+          "sentencePurposes" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SentencePurposeResponse"
+            }
+          }
+        },
+        "required" : [ "courtDate", "eventId", "id", "issuingCourt", "orderStatus", "orderType", "sentencePurposes" ]
+      },
       "CreateCourtAppearanceResponse" : {
         "type" : "object",
         "description" : "Create adjustment response",
@@ -22324,6 +22660,10 @@
             "items" : {
               "$ref" : "#/components/schemas/OffenderChargeIdResponse"
             }
+          },
+          "clonedCourtCases" : {
+            "$ref" : "#/components/schemas/ClonedCourtCaseResponse",
+            "description" : "Result of a clone court case operation when the appearance is added to a previous booking. Else null"
           }
         },
         "required" : [ "courtEventChargesIds", "id" ]
@@ -22344,6 +22684,419 @@
           }
         },
         "required" : [ "courtAppearanceIds", "id" ]
+      },
+      "LinkedCaseChargeDetails" : {
+        "type" : "object",
+        "description" : "Linked case details for a court event charge",
+        "properties" : {
+          "caseId" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "Source caseId"
+          },
+          "eventId" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "Target court eventId"
+          },
+          "dateLinked" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        },
+        "required" : [ "caseId", "dateLinked", "eventId" ]
+      },
+      "OffenceResponse" : {
+        "type" : "object",
+        "description" : "Offence",
+        "properties" : {
+          "offenceCode" : {
+            "type" : "string"
+          },
+          "statuteCode" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "description", "offenceCode", "statuteCode" ]
+      },
+      "OffenceResultCodeResponse" : {
+        "type" : "object",
+        "description" : "Offence Result Code",
+        "properties" : {
+          "chargeStatus" : {
+            "type" : "string"
+          },
+          "code" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "dispositionCode" : {
+            "type" : "string"
+          },
+          "conviction" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "chargeStatus", "code", "conviction", "description", "dispositionCode" ]
+      },
+      "OffenderChargeResponse" : {
+        "type" : "object",
+        "description" : "Offender Charge",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "offence" : {
+            "$ref" : "#/components/schemas/OffenceResponse"
+          },
+          "offencesCount" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "offenceDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "offenceEndDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "plea" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "propertyValue" : {
+            "type" : "number"
+          },
+          "totalPropertyValue" : {
+            "type" : "number"
+          },
+          "cjitCode1" : {
+            "type" : "string"
+          },
+          "cjitCode2" : {
+            "type" : "string"
+          },
+          "cjitCode3" : {
+            "type" : "string"
+          },
+          "chargeStatus" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "resultCode1" : {
+            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
+          },
+          "resultCode2" : {
+            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
+          },
+          "mostSeriousFlag" : {
+            "type" : "boolean"
+          },
+          "lidsOffenceNumber" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "required" : [ "id", "mostSeriousFlag", "offence" ]
+      },
+      "RecallCustodyDate" : {
+        "type" : "object",
+        "description" : "Recall custody return date data",
+        "properties" : {
+          "returnToCustodyDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "recallLength" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "comments" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "recallLength", "returnToCustodyDate" ]
+      },
+      "SentencePurposeResponse" : {
+        "type" : "object",
+        "description" : "Sentence Purpose",
+        "properties" : {
+          "orderId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "orderPartyCode" : {
+            "type" : "string"
+          },
+          "purposeCode" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "orderId", "orderPartyCode", "purposeCode" ]
+      },
+      "SentenceResponse" : {
+        "type" : "object",
+        "description" : "Offender Sentence",
+        "properties" : {
+          "bookingId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "sentenceSeq" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "calculationType" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "category" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "startDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "courtOrder" : {
+            "$ref" : "#/components/schemas/CourtOrderResponse"
+          },
+          "consecSequence" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "endDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "commentText" : {
+            "type" : "string"
+          },
+          "absenceCount" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "caseId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "etdCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "mtdCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "ltdCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "ardCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "crdCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "pedCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "npdCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "ledCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "sedCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "prrdCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "tariffCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "dprrdCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "tusedCalculatedDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "aggSentenceSequence" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "aggAdjustDays" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "sentenceLevel" : {
+            "type" : "string"
+          },
+          "extendedDays" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "counts" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "statusUpdateReason" : {
+            "type" : "string"
+          },
+          "statusUpdateComment" : {
+            "type" : "string"
+          },
+          "statusUpdateDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "statusUpdateStaffId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "fineAmount" : {
+            "type" : "number"
+          },
+          "dischargeDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "nomSentDetailRef" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "nomConsToSentDetailRef" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "nomConsFromSentDetailRef" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "nomConsWithSentDetailRef" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "lineSequence" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "hdcExclusionFlag" : {
+            "type" : "boolean"
+          },
+          "hdcExclusionReason" : {
+            "type" : "string"
+          },
+          "cjaAct" : {
+            "type" : "string"
+          },
+          "sled2Calc" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "startDate2Calc" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "createdDateTime" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "createdByUsername" : {
+            "type" : "string"
+          },
+          "sentenceTerms" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SentenceTermResponse"
+            }
+          },
+          "offenderCharges" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OffenderChargeResponse"
+            }
+          },
+          "missingCourtOffenderChargeIds" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "prisonId" : {
+            "type" : "string"
+          },
+          "recallCustodyDate" : {
+            "$ref" : "#/components/schemas/RecallCustodyDate"
+          }
+        },
+        "required" : [ "bookingId", "calculationType", "category", "createdByUsername", "createdDateTime", "missingCourtOffenderChargeIds", "offenderCharges", "prisonId", "sentenceSeq", "sentenceTerms", "startDate", "status" ]
+      },
+      "SentenceTermResponse" : {
+        "type" : "object",
+        "description" : "Sentence Term",
+        "properties" : {
+          "termSequence" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "sentenceTermType" : {
+            "$ref" : "#/components/schemas/CodeDescription"
+          },
+          "years" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "months" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "weeks" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "days" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "hours" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "startDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "endDate" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "lifeSentenceFlag" : {
+            "type" : "boolean"
+          },
+          "prisonId" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "lifeSentenceFlag", "prisonId", "startDate", "termSequence" ]
       },
       "CaseIdentifier" : {
         "type" : "object",
@@ -23369,755 +24122,6 @@
           }
         },
         "required" : [ "courtCases" ]
-      },
-      "CaseIdentifierResponse" : {
-        "type" : "object",
-        "description" : "Case related reference",
-        "properties" : {
-          "type" : {
-            "type" : "string",
-            "description" : "The type of case identifier",
-            "example" : "CASE/INFO#"
-          },
-          "reference" : {
-            "type" : "string",
-            "description" : "The value of the case identifier",
-            "example" : "asd/123"
-          },
-          "createDateTime" : {
-            "type" : "string",
-            "format" : "date-time",
-            "description" : "The time the case identifier was created",
-            "example" : "2020-07-17T12:34:56"
-          },
-          "modifiedDateTime" : {
-            "type" : "string",
-            "format" : "date-time",
-            "description" : "The time the case identifier was last changed",
-            "example" : "2021-07-16T12:34:56"
-          },
-          "auditModuleName" : {
-            "type" : "string",
-            "description" : "The name of the module that last changed it, indicates if this was NOMIS or the synchronisation service",
-            "example" : "DPS_SYNCHRONISATION"
-          }
-        },
-        "required" : [ "createDateTime", "reference", "type" ]
-      },
-      "ClonedCourtCaseResponse" : {
-        "type" : "object",
-        "description" : "Court Cases created due to a booking clone operation",
-        "properties" : {
-          "courtCase" : {
-            "$ref" : "#/components/schemas/CourtCaseResponse",
-            "description" : "Created court case and children"
-          },
-          "sourceCourtCase" : {
-            "$ref" : "#/components/schemas/CourtCaseResponse",
-            "description" : "Source court case and children that the cases were cloned from"
-          }
-        },
-        "required" : [ "courtCase", "sourceCourtCase" ]
-      },
-      "CourtCaseResponse" : {
-        "type" : "object",
-        "description" : "Court Case",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "offenderNo" : {
-            "type" : "string"
-          },
-          "bookingId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "primaryCaseInfoNumber" : {
-            "type" : "string"
-          },
-          "caseSequence" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "caseStatus" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "legalCaseType" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "beginDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "courtId" : {
-            "type" : "string"
-          },
-          "combinedCaseId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "sourceCombinedCaseIds" : {
-            "type" : "array",
-            "items" : {
-              "type" : "integer",
-              "format" : "int64"
-            }
-          },
-          "statusUpdateStaffId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "statusUpdateDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "statusUpdateComment" : {
-            "type" : "string"
-          },
-          "statusUpdateReason" : {
-            "type" : "string"
-          },
-          "lidsCaseId" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "lidsCombinedCaseId" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "createdDateTime" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "createdByUsername" : {
-            "type" : "string"
-          },
-          "courtEvents" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/CourtEventResponse"
-            }
-          },
-          "offenderCharges" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/OffenderChargeResponse"
-            }
-          },
-          "caseInfoNumbers" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/CaseIdentifierResponse"
-            }
-          },
-          "sentences" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SentenceResponse"
-            }
-          }
-        },
-        "required" : [ "bookingId", "caseInfoNumbers", "caseSequence", "caseStatus", "courtEvents", "courtId", "createdByUsername", "createdDateTime", "id", "legalCaseType", "offenderCharges", "offenderNo", "sentences", "sourceCombinedCaseIds" ]
-      },
-      "CourtEventChargeResponse" : {
-        "type" : "object",
-        "description" : "Court Event Charge",
-        "properties" : {
-          "eventId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "offenderCharge" : {
-            "$ref" : "#/components/schemas/OffenderChargeResponse"
-          },
-          "offencesCount" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "offenceDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "offenceEndDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "plea" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "propertyValue" : {
-            "type" : "number"
-          },
-          "totalPropertyValue" : {
-            "type" : "number"
-          },
-          "cjitCode1" : {
-            "type" : "string"
-          },
-          "cjitCode2" : {
-            "type" : "string"
-          },
-          "cjitCode3" : {
-            "type" : "string"
-          },
-          "resultCode1" : {
-            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
-          },
-          "resultCode2" : {
-            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
-          },
-          "mostSeriousFlag" : {
-            "type" : "boolean"
-          },
-          "linkedCaseDetails" : {
-            "$ref" : "#/components/schemas/LinkedCaseChargeDetails"
-          }
-        },
-        "required" : [ "eventId", "mostSeriousFlag", "offenderCharge" ]
-      },
-      "CourtEventResponse" : {
-        "type" : "object",
-        "description" : "Court Event",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "caseId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "offenderNo" : {
-            "type" : "string"
-          },
-          "eventDateTime" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "courtEventType" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "eventStatus" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "directionCode" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "judgeName" : {
-            "type" : "string"
-          },
-          "courtId" : {
-            "type" : "string"
-          },
-          "outcomeReasonCode" : {
-            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
-          },
-          "commentText" : {
-            "type" : "string"
-          },
-          "orderRequestedFlag" : {
-            "type" : "boolean"
-          },
-          "holdFlag" : {
-            "type" : "boolean"
-          },
-          "nextEventRequestFlag" : {
-            "type" : "boolean"
-          },
-          "nextEventDateTime" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "createdDateTime" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "createdByUsername" : {
-            "type" : "string"
-          },
-          "courtEventCharges" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/CourtEventChargeResponse"
-            }
-          },
-          "courtOrders" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/CourtOrderResponse"
-            }
-          }
-        },
-        "required" : [ "courtEventCharges", "courtEventType", "courtId", "courtOrders", "createdByUsername", "createdDateTime", "eventDateTime", "eventStatus", "id", "offenderNo" ]
-      },
-      "CourtOrderResponse" : {
-        "type" : "object",
-        "description" : "Court Order",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "eventId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "courtDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "issuingCourt" : {
-            "type" : "string"
-          },
-          "courtInfoId" : {
-            "type" : "string"
-          },
-          "orderType" : {
-            "type" : "string"
-          },
-          "orderStatus" : {
-            "type" : "string"
-          },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "requestDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "seriousnessLevel" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "commentText" : {
-            "type" : "string"
-          },
-          "nonReportFlag" : {
-            "type" : "boolean"
-          },
-          "sentencePurposes" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SentencePurposeResponse"
-            }
-          }
-        },
-        "required" : [ "courtDate", "eventId", "id", "issuingCourt", "orderStatus", "orderType", "sentencePurposes" ]
-      },
-      "LinkedCaseChargeDetails" : {
-        "type" : "object",
-        "description" : "Linked case details for a court event charge",
-        "properties" : {
-          "caseId" : {
-            "type" : "integer",
-            "format" : "int64",
-            "description" : "Source caseId"
-          },
-          "eventId" : {
-            "type" : "integer",
-            "format" : "int64",
-            "description" : "Target court eventId"
-          },
-          "dateLinked" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        },
-        "required" : [ "caseId", "dateLinked", "eventId" ]
-      },
-      "OffenceResponse" : {
-        "type" : "object",
-        "description" : "Offence",
-        "properties" : {
-          "offenceCode" : {
-            "type" : "string"
-          },
-          "statuteCode" : {
-            "type" : "string"
-          },
-          "description" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "description", "offenceCode", "statuteCode" ]
-      },
-      "OffenceResultCodeResponse" : {
-        "type" : "object",
-        "description" : "Offence Result Code",
-        "properties" : {
-          "chargeStatus" : {
-            "type" : "string"
-          },
-          "code" : {
-            "type" : "string"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "dispositionCode" : {
-            "type" : "string"
-          },
-          "conviction" : {
-            "type" : "boolean"
-          }
-        },
-        "required" : [ "chargeStatus", "code", "conviction", "description", "dispositionCode" ]
-      },
-      "OffenderChargeResponse" : {
-        "type" : "object",
-        "description" : "Offender Charge",
-        "properties" : {
-          "id" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "offence" : {
-            "$ref" : "#/components/schemas/OffenceResponse"
-          },
-          "offencesCount" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "offenceDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "offenceEndDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "plea" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "propertyValue" : {
-            "type" : "number"
-          },
-          "totalPropertyValue" : {
-            "type" : "number"
-          },
-          "cjitCode1" : {
-            "type" : "string"
-          },
-          "cjitCode2" : {
-            "type" : "string"
-          },
-          "cjitCode3" : {
-            "type" : "string"
-          },
-          "chargeStatus" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "resultCode1" : {
-            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
-          },
-          "resultCode2" : {
-            "$ref" : "#/components/schemas/OffenceResultCodeResponse"
-          },
-          "mostSeriousFlag" : {
-            "type" : "boolean"
-          },
-          "lidsOffenceNumber" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        },
-        "required" : [ "id", "mostSeriousFlag", "offence" ]
-      },
-      "RecallCustodyDate" : {
-        "type" : "object",
-        "description" : "Recall custody return date data",
-        "properties" : {
-          "returnToCustodyDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "recallLength" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "comments" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "recallLength", "returnToCustodyDate" ]
-      },
-      "SentencePurposeResponse" : {
-        "type" : "object",
-        "description" : "Sentence Purpose",
-        "properties" : {
-          "orderId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "orderPartyCode" : {
-            "type" : "string"
-          },
-          "purposeCode" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "orderId", "orderPartyCode", "purposeCode" ]
-      },
-      "SentenceResponse" : {
-        "type" : "object",
-        "description" : "Offender Sentence",
-        "properties" : {
-          "bookingId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "sentenceSeq" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "status" : {
-            "type" : "string"
-          },
-          "calculationType" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "category" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "startDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "courtOrder" : {
-            "$ref" : "#/components/schemas/CourtOrderResponse"
-          },
-          "consecSequence" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "endDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "commentText" : {
-            "type" : "string"
-          },
-          "absenceCount" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "caseId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "etdCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "mtdCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "ltdCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "ardCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "crdCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "pedCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "npdCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "ledCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "sedCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "prrdCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "tariffCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "dprrdCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "tusedCalculatedDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "aggSentenceSequence" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "aggAdjustDays" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "sentenceLevel" : {
-            "type" : "string"
-          },
-          "extendedDays" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "counts" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "statusUpdateReason" : {
-            "type" : "string"
-          },
-          "statusUpdateComment" : {
-            "type" : "string"
-          },
-          "statusUpdateDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "statusUpdateStaffId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "fineAmount" : {
-            "type" : "number"
-          },
-          "dischargeDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "nomSentDetailRef" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "nomConsToSentDetailRef" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "nomConsFromSentDetailRef" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "nomConsWithSentDetailRef" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "lineSequence" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "hdcExclusionFlag" : {
-            "type" : "boolean"
-          },
-          "hdcExclusionReason" : {
-            "type" : "string"
-          },
-          "cjaAct" : {
-            "type" : "string"
-          },
-          "sled2Calc" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "startDate2Calc" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "createdDateTime" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "createdByUsername" : {
-            "type" : "string"
-          },
-          "sentenceTerms" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SentenceTermResponse"
-            }
-          },
-          "offenderCharges" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/OffenderChargeResponse"
-            }
-          },
-          "missingCourtOffenderChargeIds" : {
-            "type" : "array",
-            "items" : {
-              "type" : "integer",
-              "format" : "int64"
-            }
-          },
-          "prisonId" : {
-            "type" : "string"
-          },
-          "recallCustodyDate" : {
-            "$ref" : "#/components/schemas/RecallCustodyDate"
-          }
-        },
-        "required" : [ "bookingId", "calculationType", "category", "createdByUsername", "createdDateTime", "missingCourtOffenderChargeIds", "offenderCharges", "prisonId", "sentenceSeq", "sentenceTerms", "startDate", "status" ]
-      },
-      "SentenceTermResponse" : {
-        "type" : "object",
-        "description" : "Sentence Term",
-        "properties" : {
-          "termSequence" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "sentenceTermType" : {
-            "$ref" : "#/components/schemas/CodeDescription"
-          },
-          "years" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "months" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "weeks" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "days" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "hours" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "startDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "endDate" : {
-            "type" : "string",
-            "format" : "date"
-          },
-          "lifeSentenceFlag" : {
-            "type" : "boolean"
-          },
-          "prisonId" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "lifeSentenceFlag", "prisonId", "startDate", "termSequence" ]
       },
       "CreateSentenceAdjustmentRequest" : {
         "type" : "object",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCaseMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCaseMappingService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.Co
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceRecallMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceRecallMappingsDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseAllMappingDto
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseBatchMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtChargeBatchUpdateMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtChargeMappingDto
@@ -48,14 +49,6 @@ class CourtCaseMappingService(
       )
       .retrieve()
       .awaitBodilessEntity()
-  }
-
-  suspend fun createAppearanceMapping(request: CourtAppearanceMappingDto) {
-    webClient.post()
-      .uri("/mapping/court-sentencing/court-appearances")
-      .bodyValue(request)
-      .retrieve()
-      .awaitBodilessEntityOrThrowOnConflict()
   }
 
   suspend fun createAppearanceRecallMappings(request: CourtAppearanceRecallMappingsDto) {
@@ -193,5 +186,13 @@ class CourtCaseMappingService(
       )
       .retrieve()
       .awaitBodilessEntity()
+  }
+
+  suspend fun replaceOrCreateMappings(request: CourtCaseBatchMappingDto) {
+    webClient.put()
+      .uri("/mapping/court-sentencing/court-cases/replace")
+      .bodyValue(request)
+      .retrieve()
+      .awaitBodilessEntityOrThrowOnConflict()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCasesToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCasesToNomisIntTest.kt
@@ -295,7 +295,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           ),
         )
         courtSentencingMappingApi.stubGetCaseMappingGivenDpsIdWithError(COURT_CASE_ID_FOR_CREATION, 404)
-        courtSentencingMappingApi.stubCreateCourtCaseWithErrorFollowedBySlowSuccess()
+        courtSentencingMappingApi.stubCreateCourtCaseWithErrorFollowedBySuccess()
         publishCreateCourtCaseDomainEvent()
 
         await untilCallTo { courtSentencingApi.getCountFor("/legacy/court-case/$COURT_CASE_ID_FOR_CREATION") } matches { it == 1 }
@@ -480,7 +480,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
         )
 
         courtSentencingMappingApi.stubGetCourtAppearanceMappingGivenDpsIdWithError(DPS_COURT_APPEARANCE_ID, 404)
-        courtSentencingMappingApi.stubCreateCourtAppearance()
+        courtSentencingMappingApi.stubReplaceOrCreateMappings()
         // stub two mappings for charges out of the 4 - which makes 2 creates and 2 updates
         courtSentencingMappingApi.stubGetCourtChargeMappingGivenDpsId(DPS_COURT_CHARGE_ID, NOMIS_COURT_CHARGE_ID)
         courtSentencingMappingApi.stubGetCourtChargeMappingGivenDpsId(
@@ -572,16 +572,16 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
 
         await untilAsserted {
           courtSentencingMappingApi.verify(
-            postRequestedFor(urlEqualTo("/mapping/court-sentencing/court-appearances"))
+            putRequestedFor(urlEqualTo("/mapping/court-sentencing/court-cases/replace"))
               .withRequestBody(
                 matchingJsonPath(
-                  "dpsCourtAppearanceId",
+                  "courtAppearances[0].dpsCourtAppearanceId",
                   equalTo(DPS_COURT_APPEARANCE_ID),
                 ),
               )
               .withRequestBody(
                 matchingJsonPath(
-                  "nomisCourtAppearanceId",
+                  "courtAppearances[0].nomisCourtAppearanceId",
                   equalTo(
                     NOMIS_COURT_APPEARANCE_ID.toString(),
                   ),
@@ -649,7 +649,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           nomisCourtCaseId = NOMIS_COURT_CASE_ID_FOR_CREATION,
         )
         courtSentencingMappingApi.stubGetCourtAppearanceMappingGivenDpsIdWithError(DPS_COURT_APPEARANCE_ID, 404)
-        courtSentencingMappingApi.stubCreateCourtAppearanceWithErrorFollowedBySlowSuccess()
+        courtSentencingMappingApi.stubReplaceOrCreateMappingsWithErrorFollowedBySuccess()
 
         courtSentencingMappingApi.stubGetCourtChargeMappingGivenDpsId(DPS_COURT_CHARGE_ID, NOMIS_COURT_CHARGE_ID)
         courtSentencingMappingApi.stubGetCourtChargeMappingGivenDpsId(
@@ -690,16 +690,16 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
         await untilAsserted {
           courtSentencingMappingApi.verify(
             2,
-            postRequestedFor(urlEqualTo("/mapping/court-sentencing/court-appearances"))
+            putRequestedFor(urlEqualTo("/mapping/court-sentencing/court-cases/replace"))
               .withRequestBody(
                 matchingJsonPath(
-                  "dpsCourtAppearanceId",
+                  "courtAppearances[0].dpsCourtAppearanceId",
                   equalTo(DPS_COURT_APPEARANCE_ID),
                 ),
               )
               .withRequestBody(
                 matchingJsonPath(
-                  "nomisCourtAppearanceId",
+                  "courtAppearances[0].nomisCourtAppearanceId",
                   equalTo(
                     NOMIS_COURT_APPEARANCE_ID.toString(),
                   ),
@@ -737,10 +737,10 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           nomisCourtCaseId = NOMIS_COURT_CASE_ID_FOR_CREATION,
         )
         courtSentencingMappingApi.stubGetCourtAppearanceMappingGivenDpsIdWithError(DPS_COURT_APPEARANCE_ID, 404)
-        courtSentencingMappingApi.stubCreateCourtAppearance()
+        courtSentencingMappingApi.stubReplaceOrCreateMappings()
 
         // a parent entity has initially not been created but then is available on retry
-        courtSentencingMappingApi.stubGetCourtChargeNotFoundFollowedBySlowSuccess(
+        courtSentencingMappingApi.stubGetCourtChargeNotFoundFollowedBySuccess(
           DPS_COURT_CHARGE_ID,
           NOMIS_COURT_CHARGE_ID,
         )
@@ -821,7 +821,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           DPS_COURT_APPEARANCE_ID,
           NOMIS_COURT_APPEARANCE_ID,
         )
-        courtSentencingMappingApi.stubCreateCourtAppearance()
+        courtSentencingMappingApi.stubReplaceOrCreateMappings()
         // mappings found for all 4 charges
         courtSentencingMappingApi.stubGetCourtChargeMappingGivenDpsId(DPS_COURT_CHARGE_ID, NOMIS_COURT_CHARGE_ID)
         courtSentencingMappingApi.stubGetCourtChargeMappingGivenDpsId(
@@ -1199,7 +1199,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           nomisCourtCaseId = NOMIS_COURT_CASE_ID_FOR_CREATION,
         )
         courtSentencingMappingApi.stubGetCourtChargeMappingGivenDpsIdWithError(DPS_COURT_CHARGE_ID, 404)
-        courtSentencingMappingApi.stubCreateCourtChargeWithErrorFollowedBySlowSuccess()
+        courtSentencingMappingApi.stubCreateCourtChargeWithErrorFollowedBySuccess()
         publishCreateCourtChargeDomainEvent()
 
         await untilCallTo { courtSentencingApi.getCountFor("/legacy/charge/$DPS_COURT_CHARGE_ID") } matches { it == 1 }
@@ -1387,7 +1387,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
 
       @Test
       fun `will not update an court case in NOMIS`() {
-        waitForAnyProcessingToComplete()
+        waitForAnyProcessingToComplete(3)
 
         courtSentencingNomisApi.verify(
           0,
@@ -1762,7 +1762,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
         )
 
         courtSentencingMappingApi.stubGetSentenceMappingGivenDpsIdWithError(DPS_SENTENCE_ID, 404)
-        courtSentencingMappingApi.stubCreateSentenceWithErrorFollowedBySlowSuccess()
+        courtSentencingMappingApi.stubCreateSentenceWithErrorFollowedBySuccess()
 
         publishCreateSentenceDomainEvent()
 
@@ -1852,7 +1852,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
         courtSentencingMappingApi.stubCreateSentence()
 
         // a parent entity has initially not been created but then is available on retry
-        courtSentencingMappingApi.stubGetCourtChargeNotFoundFollowedBySlowSuccess(
+        courtSentencingMappingApi.stubGetCourtChargeNotFoundFollowedBySuccess(
           DPS_COURT_CHARGE_ID,
           NOMIS_COURT_CHARGE_ID,
         )
@@ -2035,7 +2035,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
         )
 
         courtSentencingMappingApi.stubGetSentenceMappingGivenDpsIdWithError(DPS_SENTENCE_ID, 404)
-        courtSentencingMappingApi.stubCreateSentenceWithErrorFollowedBySlowSuccess()
+        courtSentencingMappingApi.stubCreateSentenceWithErrorFollowedBySuccess()
 
         publishCreateSentenceRequiringResyncDomainEvent()
 
@@ -2261,7 +2261,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
 
       @Test
       fun `will create failed telemetry`() {
-        waitForAnyProcessingToComplete()
+        waitForAnyProcessingToComplete(3)
 
         await untilAsserted {
           verify(telemetryClient, times(3)).trackEvent(
@@ -2601,7 +2601,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           nomisBookingId = NOMIS_BOOKING_ID,
         )
 
-        courtSentencingMappingApi.stubCreateSentenceTermWithErrorFollowedBySlowSuccess()
+        courtSentencingMappingApi.stubCreateSentenceTermWithErrorFollowedBySuccess()
 
         publishCreatePeriodLengthDomainEvent()
 
@@ -3168,7 +3168,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
       inner class HappyPathWhenMappingFailsOnce {
         @BeforeEach
         fun setUp() {
-          courtSentencingMappingApi.stubCreateWithErrorFollowedBySlowSuccess(
+          courtSentencingMappingApi.stubCreateWithErrorFollowedBySuccess(
             url = "/mapping/court-sentencing/court-appearances/recall",
             name = "Recall Appearance",
           )

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -184,6 +184,7 @@ hmpps.sqs:
         ]}
       dlqMaxReceiveCount: 3
       visibilityTimeout: 120
+      errorVisibilityTimeout: 0
     fromnomiscourtsentencing:
       queueName: "court-sentencing-from-nomis-${random.uuid}"
     alerts:


### PR DESCRIPTION
For the next phase the createAppearance NOMIS API can return the cloned court cases when appearance created on an old booking, these will be sent in the same payload for the mappings service. So this change should end up with the same behaviour except using a different mapping endpoint.

Also speeded up tests