### PR TITLE
SDIT-2804 Remove message listener beans before the application starts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManager.kt
@@ -3,11 +3,14 @@ package uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.context.event.EventListener
-import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.ActivitiesReconService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.DomainEventListener
@@ -17,14 +20,11 @@ import java.time.LocalDate
 @Service
 class BatchManager(
   @Value($$"${batch.type}") private val batchType: String,
-  private val beanDestroyer: BeanDestroyer,
   private val activitiesReconService: ActivitiesReconService,
 ) {
 
   @EventListener
   fun onApplicationEvent(event: ContextRefreshedEvent) = runBlocking {
-    beanDestroyer.destroyBeans(DomainEventListener::class.java)
-
     when (batchType) {
       "ALLOCATION_RECON" -> activitiesReconService.allocationReconciliationReport()
       "ATTENDANCE_RECON" -> activitiesReconService.attendanceReconciliationReport(LocalDate.now().minusDays(1))
@@ -40,12 +40,29 @@ class BatchManager(
   }
 }
 
+/**
+ * This configuration is used in batch mode to remove all event listeners, otherwise they will read messages from queues
+ * which should be left to the main application.
+ */
+@Configuration
 @ConditionalOnProperty(name = ["batch.enabled"], havingValue = "true")
-@Component
-class BeanDestroyer(applicationContext: ConfigurableApplicationContext) {
-  private val beanFactory = applicationContext.autowireCapableBeanFactory
+class BatchConfiguration {
 
-  fun destroyBeans(vararg types: Class<*>) = types.forEach { type ->
-    beanFactory.getBeanProvider(type).forEach { beanFactory.destroyBean(it) }
+  private inline fun <reified T> DefaultListableBeanFactory.isBeanAssignableFrom(beanName: String): Boolean {
+    // Look for a @Component bean
+    getBeanDefinition(beanName).beanClassName
+      ?.let { runCatching { Class.forName(it, false, beanClassLoader) }.getOrNull() }
+      ?.let { return T::class.java.isAssignableFrom(it) }
+
+    // Check for a factory-method @Bean
+    return runCatching { getType(beanName, false) }.getOrNull()
+      ?.let { T::class.java.isAssignableFrom(it) } == true
+  }
+
+  @Bean
+  fun pruneDomainEventListenerBeans(): BeanFactoryPostProcessor = BeanFactoryPostProcessor { beanFactory ->
+    (beanFactory as DefaultListableBeanFactory).beanDefinitionNames
+      .filter { name -> beanFactory.isBeanAssignableFrom<DomainEventListener>(name) }
+      .forEach { beanFactory.removeBeanDefinition(it) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManagerTest.kt
@@ -15,13 +15,11 @@ import org.springframework.boot.test.system.OutputCaptureExtension
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.event.ContextRefreshedEvent
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.ActivitiesReconService
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.DomainEventListener
 
 @ExtendWith(OutputCaptureExtension::class)
 class BatchManagerTest {
 
   private val activitiesReconService = mock<ActivitiesReconService>()
-  private val beanDestroyer = mock<BeanDestroyer>()
   private val event = mock<ContextRefreshedEvent>()
   private val context = mock<ConfigurableApplicationContext>()
 
@@ -31,17 +29,8 @@ class BatchManagerTest {
   }
 
   @Test
-  fun `should destroy queue listener beans`() = runTest {
-    val batchManager = BatchManager("ALLOCATION_RECON", beanDestroyer, activitiesReconService)
-
-    batchManager.onApplicationEvent(event)
-
-    verify(beanDestroyer).destroyBeans(DomainEventListener::class.java)
-  }
-
-  @Test
   fun `should log for invalid batch type`(output: CapturedOutput) = runTest {
-    val batchManager = BatchManager("INVALID_BATCH_TYPE", beanDestroyer, activitiesReconService)
+    val batchManager = BatchManager("INVALID_BATCH_TYPE", activitiesReconService)
 
     batchManager.onApplicationEvent(event)
 
@@ -52,7 +41,7 @@ class BatchManagerTest {
 
   @Test
   fun `should call the allocation reconciliation service`() = runTest {
-    val batchManager = BatchManager("ALLOCATION_RECON", beanDestroyer, activitiesReconService)
+    val batchManager = BatchManager("ALLOCATION_RECON", activitiesReconService)
 
     batchManager.onApplicationEvent(event)
 
@@ -62,7 +51,7 @@ class BatchManagerTest {
 
   @Test
   fun `should call the attendance reconciliation service`() = runTest {
-    val batchManager = BatchManager("ATTENDANCE_RECON", beanDestroyer, activitiesReconService)
+    val batchManager = BatchManager("ATTENDANCE_RECON", activitiesReconService)
 
     batchManager.onApplicationEvent(event)
 
@@ -72,7 +61,7 @@ class BatchManagerTest {
 
   @Test
   fun `should call the suspended allocation reconciliation service`() = runTest {
-    val batchManager = BatchManager("SUSPENDED_ALLOCATION_RECON", beanDestroyer, activitiesReconService)
+    val batchManager = BatchManager("SUSPENDED_ALLOCATION_RECON", activitiesReconService)
 
     batchManager.onApplicationEvent(event)
 


### PR DESCRIPTION
The previous method (BeanDestroyer) didn't destroy the listener beans until after the application started. In the small amount of time inbetween some messages were [pulled from their queue and processed](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2Fresourcegroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA3WNsQ6CMBRFd7%252FibcDwyLOmqZIwMBlXww9UeJEm0L60VRY%252FXljcHG%252FOybmdSB%252FtwOnwgXXiyNC7ha%252FsOdrMIzw4r8weynGbeUOlIqWRzqgMkGlIN0QV1DX8E8wuVL98J3IPM998ytYPDG0LxbSIJJToUth%252BMQf0YXEJX7JHMbKEmNHOcxhsdsEnVBdljifSSt76WXwBcWcxKMUAAAA%253D/limit/5000).

This new method uses a BeanFactoryPostProcessor which runs after beans are created but before the application starts so should not read any messages.