### PR TITLE
SDIT-2804 Fail batch jobs if type is invalid

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManager.kt
@@ -13,23 +13,31 @@ import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.ActivitiesReconService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.ALLOCATION_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.ATTENDANCE_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.SUSPENDED_ALLOCATION_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.DomainEventListener
 import java.time.LocalDate
+
+enum class BatchType {
+  ALLOCATION_RECON,
+  ATTENDANCE_RECON,
+  SUSPENDED_ALLOCATION_RECON,
+}
 
 @ConditionalOnProperty(name = ["batch.enabled"], havingValue = "true")
 @Service
 class BatchManager(
-  @Value($$"${batch.type}") private val batchType: String,
+  @Value($$"${batch.type}") private val batchType: BatchType,
   private val activitiesReconService: ActivitiesReconService,
 ) {
 
   @EventListener
   fun onApplicationEvent(event: ContextRefreshedEvent) = runBlocking {
     when (batchType) {
-      "ALLOCATION_RECON" -> activitiesReconService.allocationReconciliationReport()
-      "ATTENDANCE_RECON" -> activitiesReconService.attendanceReconciliationReport(LocalDate.now().minusDays(1))
-      "SUSPENDED_ALLOCATION_RECON" -> activitiesReconService.suspendedAllocationReconciliationReport()
-      else -> log.error("Batch type $batchType not supported")
+      ALLOCATION_RECON -> activitiesReconService.allocationReconciliationReport()
+      ATTENDANCE_RECON -> activitiesReconService.attendanceReconciliationReport(LocalDate.now().minusDays(1))
+      SUSPENDED_ALLOCATION_RECON -> activitiesReconService.suspendedAllocationReconciliationReport()
     }
   }.also { event.closeApplication() }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManagerTest.kt
@@ -1,20 +1,20 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch
 
 import kotlinx.coroutines.test.runTest
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.event.ContextRefreshedEvent
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.ActivitiesReconService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.ALLOCATION_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.ATTENDANCE_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.SUSPENDED_ALLOCATION_RECON
 
 @ExtendWith(OutputCaptureExtension::class)
 class BatchManagerTest {
@@ -29,19 +29,8 @@ class BatchManagerTest {
   }
 
   @Test
-  fun `should log for invalid batch type`(output: CapturedOutput) = runTest {
-    val batchManager = BatchManager("INVALID_BATCH_TYPE", activitiesReconService)
-
-    batchManager.onApplicationEvent(event)
-
-    verify(activitiesReconService, never()).allocationReconciliationReport()
-    verify(context).close()
-    assertThat(output).contains("INVALID_BATCH_TYPE not supported")
-  }
-
-  @Test
   fun `should call the allocation reconciliation service`() = runTest {
-    val batchManager = BatchManager("ALLOCATION_RECON", activitiesReconService)
+    val batchManager = BatchManager(ALLOCATION_RECON, activitiesReconService)
 
     batchManager.onApplicationEvent(event)
 
@@ -51,7 +40,7 @@ class BatchManagerTest {
 
   @Test
   fun `should call the attendance reconciliation service`() = runTest {
-    val batchManager = BatchManager("ATTENDANCE_RECON", activitiesReconService)
+    val batchManager = BatchManager(ATTENDANCE_RECON, activitiesReconService)
 
     batchManager.onApplicationEvent(event)
 
@@ -61,7 +50,7 @@ class BatchManagerTest {
 
   @Test
   fun `should call the suspended allocation reconciliation service`() = runTest {
-    val batchManager = BatchManager("SUSPENDED_ALLOCATION_RECON", activitiesReconService)
+    val batchManager = BatchManager(SUSPENDED_ALLOCATION_RECON, activitiesReconService)
 
     batchManager.onApplicationEvent(event)
 


### PR DESCRIPTION
Currently the application ends gracefully if the batch type is not supported. Change to an enum and the application fails to start, which should cause the cronjob to fail.

Unfortunately I don't think we can create integration tests for failed application starts.