### PR TITLE
SDIT-3009 Prep work for recalls on previous bookings

### DIFF
--- a/openapi-specs/nomis-prisoner-api-docs.json
+++ b/openapi-specs/nomis-prisoner-api-docs.json
@@ -7,7 +7,7 @@
       "name" : "HMPPS Digital Studio",
       "email" : "feedback@digital.justice.gov.uk"
     },
-    "version" : "2025-08-27.483.b49951c"
+    "version" : "2025-08-29.485.1090266"
   },
   "servers" : [ {
     "url" : "https://nomis-prisoner-api-dev.prison.service.justice.gov.uk",
@@ -24005,6 +24005,10 @@
             "items" : {
               "$ref" : "#/components/schemas/SentenceIdAndAdjustmentIds"
             }
+          },
+          "clonedCourtCases" : {
+            "$ref" : "#/components/schemas/BookingCourtCaseCloneResponse",
+            "description" : "Result of a clone court case operation when the recall sentences is added to a previous booking. Else null"
           }
         },
         "required" : [ "courtEventIds", "sentenceAdjustmentsActivated" ]


### PR DESCRIPTION
TODO - adding the booking clone response - for now assume it is always null

No real change other than we will send separate adjustment sync messages for each individual adjustment per sentence. This is because for clone cases as well as updating adjustments, we will be creating them which aren't idempotent so we need a message each. This has no functional effect at all (and typically a sentence won't have more than one adjustment anyway).