### PR TITLE
SDIT-2804 Improve batch job tracing and fix Spring bean warning

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManager.kt
@@ -1,14 +1,12 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch
 
+import io.opentelemetry.instrumentation.annotations.SpanAttribute
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor
-import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ConfigurableApplicationContext
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
@@ -16,7 +14,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities.ActivitiesR
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.ALLOCATION_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.ATTENDANCE_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.SUSPENDED_ALLOCATION_RECON
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.DomainEventListener
 import java.time.LocalDate
 
 enum class BatchType {
@@ -33,44 +30,20 @@ class BatchManager(
 ) {
 
   @EventListener
-  fun onApplicationEvent(event: ContextRefreshedEvent) = runBlocking {
+  fun onApplicationEvent(event: ContextRefreshedEvent) = runBatchJob(batchType).also { event.closeApplication() }
+
+  @WithSpan
+  fun runBatchJob(@SpanAttribute batchType: BatchType) = runBlocking {
     when (batchType) {
       ALLOCATION_RECON -> activitiesReconService.allocationReconciliationReport()
       ATTENDANCE_RECON -> activitiesReconService.attendanceReconciliationReport(LocalDate.now().minusDays(1))
       SUSPENDED_ALLOCATION_RECON -> activitiesReconService.suspendedAllocationReconciliationReport()
     }
-  }.also { event.closeApplication() }
+  }
 
   private fun ContextRefreshedEvent.closeApplication() = (this.applicationContext as ConfigurableApplicationContext).close()
 
   companion object {
     val log = LoggerFactory.getLogger(this::class.java)
-  }
-}
-
-/**
- * This configuration is used in batch mode to remove all event listeners, otherwise they will read messages from queues
- * which should be left to the main application.
- */
-@Configuration
-@ConditionalOnProperty(name = ["batch.enabled"], havingValue = "true")
-class BatchConfiguration {
-
-  private inline fun <reified T> DefaultListableBeanFactory.isBeanAssignableFrom(beanName: String): Boolean {
-    // Look for a @Component bean
-    getBeanDefinition(beanName).beanClassName
-      ?.let { runCatching { Class.forName(it, false, beanClassLoader) }.getOrNull() }
-      ?.let { return T::class.java.isAssignableFrom(it) }
-
-    // Check for a factory-method @Bean
-    return runCatching { getType(beanName, false) }.getOrNull()
-      ?.let { T::class.java.isAssignableFrom(it) } == true
-  }
-
-  @Bean
-  fun pruneDomainEventListenerBeans(): BeanFactoryPostProcessor = BeanFactoryPostProcessor { beanFactory ->
-    (beanFactory as DefaultListableBeanFactory).beanDefinitionNames
-      .filter { name -> beanFactory.isBeanAssignableFrom<DomainEventListener>(name) }
-      .forEach { beanFactory.removeBeanDefinition(it) }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/DomainEventListenerSuppressor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/DomainEventListenerSuppressor.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch
+
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.DomainEventListener
+
+/**
+ * This bean is used in batch mode to remove all event listeners, otherwise they will read messages from queues
+ * which should be left to the main application.
+ */
+@Component
+@ConditionalOnProperty(name = ["batch.enabled"], havingValue = "true")
+class DomainEventListenerSuppressor : BeanFactoryPostProcessor {
+
+  override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
+    (beanFactory as DefaultListableBeanFactory).beanDefinitionNames
+      .filter { name -> beanFactory.isBeanAssignableFrom<DomainEventListener>(name) }
+      .forEach { beanFactory.removeBeanDefinition(it) }
+  }
+
+  private inline fun <reified T> DefaultListableBeanFactory.isBeanAssignableFrom(beanName: String): Boolean {
+    // Look for a @Component bean
+    getBeanDefinition(beanName).beanClassName
+      ?.let { runCatching { Class.forName(it, false, beanClassLoader) }.getOrNull() }
+      ?.let { return T::class.java.isAssignableFrom(it) }
+
+    // Check for a factory-method @Bean
+    return runCatching { getType(beanName, false) }.getOrNull()
+      ?.let { T::class.java.isAssignableFrom(it) } == true
+  }
+}


### PR DESCRIPTION
Tracing: previously each step in the batch job was running in a different span so had different OperationIds in App Insights. They now all have the same OperationId, have a better OperationName (BatchManager.runBatchJob) and have a dependency that includes the `batchType`.

BeanFactoryPostProcessor: Spring was issuing a warning about creating a BeanFactoryPostProcessor as a non-static method in a Configuration class which can cause container lifecycle issues. Moved to a @Component instead and Spring is happy.