### PR TITLE
SDIT-3025 Increase errorVisibilityTimeout for adjustments to 1 second

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -198,6 +198,8 @@ hmpps.sqs:
       errorVisibilityTimeout: 5
     courtsentencing:
       errorVisibilityTimeout: 1
+    sentencing:
+      errorVisibilityTimeout: 1
     personalrelationships:
       errorVisibilityTimeout: 5
     activity:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -124,6 +124,7 @@ hmpps.sqs:
         "release-date-adjustments.adjustment.deleted"]}
       dlqMaxReceiveCount: 3
       visibilityTimeout: 120
+      errorVisibilityTimeout: 0
     adjudication:
       queueName: "adjudication-${random.uuid}"
       dlqName: "adjudication-dlq-${random.uuid}"


### PR DESCRIPTION
Should solve the issue when an adjustment is updated and deleted at the same time, which results on messages being added to the DLQ until next retry