### PR TITLE
SDIT-2804 Wait for batch jobs to finish, don't fire and forget

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -52,6 +52,21 @@ generic-service:
     REPORTS_CONTACT-PERSON_PRISONER-CONTACT_RECONCILIATION_PAGE-SIZE: 5
     REPORTS_CONTACT-PERSON_PERSON-CONTACT_RECONCILIATION_PAGE-SIZE: 10
 
+  # TODO Remove these from dev - just here for testing
+  batchjobs:
+    - name: allocations-recon
+      type: ALLOCATION_RECON
+      schedule: "5 7 * * *"
+    - name: attendances-recon
+      type: ATTENDANCE_RECON
+      schedule: "5 1 * * *"
+    - name: con-per-prf-det-recon
+      type: CONTACT_PERSON_PROFILE_DETAILS_RECON
+      schedule: "30 3 * * *"
+    - name: suspended-alloc-recon
+      type: SUSPENDED_ALLOCATION_RECON
+      schedule: "35 7 * * *"
+
 generic-prometheus-alerts:
   businessHoursOnly: true
   alertSeverity: syscon-nonprod

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesReconService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesReconService.kt
@@ -1,10 +1,8 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities
 
 import com.microsoft.applicationinsights.TelemetryClient
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.config.trackEvent
@@ -19,7 +17,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.At
 class ActivitiesReconService(
   private val telemetryClient: TelemetryClient,
   private val activitiesNomisApiService: ActivitiesNomisApiService,
-  private val reportScope: CoroutineScope,
   private val activitiesApiService: ActivitiesApiService,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
@@ -38,7 +35,7 @@ class ActivitiesReconService(
       throw e
     }
 
-    prisons.forEach { reportScope.launch { allocationsReconciliationReport(it.agencyId) } }
+    prisons.forEach { allocationsReconciliationReport(it.agencyId) }
   }
 
   suspend fun allocationsReconciliationReport(prisonId: String) = try {
@@ -68,7 +65,7 @@ class ActivitiesReconService(
       throw e
     }
 
-    prisons.forEach { reportScope.launch { suspendedAllocationsReconciliationReport(it.agencyId) } }
+    prisons.forEach { suspendedAllocationsReconciliationReport(it.agencyId) }
   }
 
   suspend fun suspendedAllocationsReconciliationReport(prisonId: String) = try {
@@ -98,7 +95,7 @@ class ActivitiesReconService(
       throw e
     }
 
-    prisons.forEach { reportScope.launch { attendancesReconciliationReport(it.agencyId, date) } }
+    prisons.forEach { attendancesReconciliationReport(it.agencyId, date) }
   }
 
   suspend fun attendancesReconciliationReport(prisonId: String, date: LocalDate) = try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/profiledetails/ContactPersonProfileDetailsReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/personalrelationships/profiledetails/ContactPersonProfileDetailsReconciliationService.kt
@@ -49,7 +49,6 @@ class ContactPersonProfileDetailsReconciliationService(
   @Value("\${feature.recon.contact-person.profile-details:true}") private val reconciliationTurnedOn: Boolean = true,
   @Autowired private val telemetryClient: TelemetryClient,
   @Autowired(required = false) private val channelActivityDebugger: ContactPersonProfileDetailsChannelActivityDebugger? = null,
-  @Autowired private val reportScope: CoroutineScope,
 ) {
   companion object {
     const val TELEMETRY_PREFIX = "contact-person-profile-details-reconciliation"
@@ -63,23 +62,21 @@ class ContactPersonProfileDetailsReconciliationService(
       mapOf("active-prisoners" to activePrisonersCount.toString()),
     )
 
-    reportScope.launch {
-      runCatching { generateReconciliationReport(activePrisonersCount) }
-        .onSuccess {
-          telemetryClient.trackEvent(
-            "$TELEMETRY_PREFIX-report-${if (it.isEmpty()) "success" else "failed"}",
-            mapOf(
-              "active-prisoners" to activePrisonersCount.toString(),
-              "mismatch-count" to it.size.toString(),
-              "mismatch-prisoners" to it.toString(),
-            ),
-          )
-        }
-        .onFailure { e ->
-          telemetryClient.trackEvent("$TELEMETRY_PREFIX-report-error", mapOf("error" to "${e.message}"))
-          log.error("Failed to generate contact person profile details reconciliation report", e)
-        }
-    }
+    runCatching { generateReconciliationReport(activePrisonersCount) }
+      .onSuccess {
+        telemetryClient.trackEvent(
+          "$TELEMETRY_PREFIX-report-${if (it.isEmpty()) "success" else "failed"}",
+          mapOf(
+            "active-prisoners" to activePrisonersCount.toString(),
+            "mismatch-count" to it.size.toString(),
+            "mismatch-prisoners" to it.toString(),
+          ),
+        )
+      }
+      .onFailure { e ->
+        telemetryClient.trackEvent("$TELEMETRY_PREFIX-report-error", mapOf("error" to "${e.message}"))
+        log.error("Failed to generate contact person profile details reconciliation report", e)
+      }
   }
 
   suspend fun generateReconciliationReport(activePrisonersCount: Long): Mismatches = if (reconciliationTurnedOn) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesReconTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/activities/ActivitiesReconTest.kt
@@ -3,7 +3,6 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.activities
 
 import com.microsoft.applicationinsights.TelemetryClient
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -36,9 +35,8 @@ class ActivitiesReconTest {
 
   private val telemetryClient: TelemetryClient = mock()
   private val nomisApiService: ActivitiesNomisApiService = mock()
-  private val reportScope: CoroutineScope = mock()
   private val activitiesApiService: ActivitiesApiService = mock()
-  private val activitiesReconService = ActivitiesReconService(telemetryClient, nomisApiService, reportScope, activitiesApiService)
+  private val activitiesReconService = ActivitiesReconService(telemetryClient, nomisApiService, activitiesApiService)
 
   @Nested
   inner class AllocationReconciliationReport {


### PR DESCRIPTION
At some point we deliberately designed the reconciliation jobs to be "fire and forget" using `reportScope.launch` so they didn't mess with the main threadpools. I thought an initial `runBlocking` would override this behaviour but no - in long running reconciliations the App is shutting down before the reconciliation finishes.

As these reconciliation jobs are now running in a dedicated Cronjob and have nothing to do with the main pods, we don't care about that any more. The batch jobs can eat all the threads they like.