### PR TITLE
SDIT-2804 Try more reconciliations with cronjob template in preprod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -63,6 +63,22 @@ generic-service:
     - name: activity-mappings
       type: DELETE_UNKNOWN_ACTIVITY_MAPPINGS
       schedule: "15 7 * * 1-5"
+    # All of the batchjobs below exist only for testing the work with the new cronjob template in preprod. Once OK these need moving to values-prod.yaml with schedule matching the current Cronjob.
+    - name: crt-case-prsner-recon
+      type: COURT_CASE_PRISONER_RECON
+      schedule: "10 3 * * *"
+    - name: csip-recon
+      type: CSIP_RECON
+      schedule: "5 1 * * *"
+    - name: incentives-recon
+      type: INCENTIVES_RECON
+      schedule: "10 4 * * *"
+    - name: prisner-contact-recon
+      type: PRISONER_CONTACT_RECON
+      schedule: "40 0 * * *"
+    - name: priner-restrict-recon
+      type: PRISONER_RESTRICTION_RECON
+      schedule: "0 5 * * *"
 
 
 generic-prometheus-alerts:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManager.kt
@@ -22,12 +22,21 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.ATTEND
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.CASE_NOTES_ACTIVE_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.CASE_NOTES_FULL_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.CONTACT_PERSON_PROFILE_DETAILS_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.COURT_CASE_PRISONER_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.CSIP_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.DELETE_UNKNOWN_ACTIVITY_MAPPINGS
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.INCENTIVES_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.PERSON_CONTACT_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.PRISONER_CONTACT_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.PRISONER_RESTRICTION_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.PURGE_ACTIVITY_DLQ
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.SUSPENDED_ALLOCATION_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.casenotes.CaseNotesReconciliationService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.courtsentencing.CourtSentencingReconciliationService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.csip.CSIPReconciliationService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.incentives.IncentivesReconciliationService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.personalrelationships.ContactPersonReconciliationService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.personalrelationships.PrisonerRestrictionsReconciliationService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.personalrelationships.profiledetails.ContactPersonProfileDetailsReconciliationService
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import java.lang.IllegalArgumentException
@@ -42,8 +51,13 @@ enum class BatchType {
   CASE_NOTES_ACTIVE_RECON,
   CASE_NOTES_FULL_RECON,
   CONTACT_PERSON_PROFILE_DETAILS_RECON,
+  CSIP_RECON,
   DELETE_UNKNOWN_ACTIVITY_MAPPINGS,
+  INCENTIVES_RECON,
   PERSON_CONTACT_RECON,
+  PRISONER_CONTACT_RECON,
+  COURT_CASE_PRISONER_RECON,
+  PRISONER_RESTRICTION_RECON,
   PURGE_ACTIVITY_DLQ,
   SUSPENDED_ALLOCATION_RECON,
 }
@@ -60,7 +74,11 @@ class BatchManager(
   private val caseNotesReconciliationService: CaseNotesReconciliationService,
   private val contactPersonProfileDetailsReconService: ContactPersonProfileDetailsReconciliationService,
   private val contactPersonReconciliationService: ContactPersonReconciliationService,
+  private val courtSentencingReconciliationService: CourtSentencingReconciliationService,
+  private val csipReconciliationService: CSIPReconciliationService,
   private val hmppsQueueService: HmppsQueueService,
+  private val incentivesReconciliationService: IncentivesReconciliationService,
+  private val prisonerRestrictionsReconciliationService: PrisonerRestrictionsReconciliationService,
   private val schedulesService: SchedulesService,
 ) {
 
@@ -78,8 +96,13 @@ class BatchManager(
       CASE_NOTES_ACTIVE_RECON -> caseNotesReconciliationService.generateReconciliationReport(activeOnly = true)
       CASE_NOTES_FULL_RECON -> caseNotesReconciliationService.generateReconciliationReport(activeOnly = false)
       CONTACT_PERSON_PROFILE_DETAILS_RECON -> contactPersonProfileDetailsReconService.reconciliationReport()
+      COURT_CASE_PRISONER_RECON -> courtSentencingReconciliationService.generateCourtCasePrisonerReconciliationReportBatch()
+      CSIP_RECON -> csipReconciliationService.generateCSIPReconciliationReport()
       DELETE_UNKNOWN_ACTIVITY_MAPPINGS -> schedulesService.deleteUnknownMappings()
+      INCENTIVES_RECON -> incentivesReconciliationService.generateIncentiveReconciliationReport()
       PERSON_CONTACT_RECON -> contactPersonReconciliationService.generatePersonContactReconciliationReportBatch()
+      PRISONER_CONTACT_RECON -> contactPersonReconciliationService.generatePrisonerContactReconciliationReportBatch()
+      PRISONER_RESTRICTION_RECON -> prisonerRestrictionsReconciliationService.generatePrisonerRestrictionsReconciliationReportBatch()
       PURGE_ACTIVITY_DLQ -> purgeQueue(activitiesDlqName)
       SUSPENDED_ALLOCATION_RECON -> activitiesReconService.suspendedAllocationReconciliationReport()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/csip/CSIPReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/csip/CSIPReconciliationService.kt
@@ -32,6 +32,26 @@ class CSIPReconciliationService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  suspend fun generateCSIPReconciliationReport() {
+    val activePrisonersCount = nomisApiService.getActivePrisoners(0, 1).totalElements
+
+    telemetryClient.trackEvent("csip-reports-reconciliation-requested", mapOf("active-prisoners" to activePrisonersCount.toString()))
+    log.info("CSIP reconciliation report requested for $activePrisonersCount active prisoners")
+
+    runCatching { generateReconciliationReport(activePrisonersCount) }
+      .onSuccess {
+        log.info("CSIP reconciliation report completed with ${it.size} mismatches")
+        telemetryClient.trackEvent(
+          "csip-reports-reconciliation-report",
+          mapOf("mismatch-count" to it.size.toString(), "success" to "true") + it.asMap(),
+        )
+      }
+      .onFailure {
+        telemetryClient.trackEvent("csip-reports-reconciliation-report", mapOf("success" to "false"))
+        log.error("CSIP reconciliation report failed", it)
+      }
+  }
+
   suspend fun generateReconciliationReport(activePrisonersCount: Long): List<MismatchCSIPs> = activePrisonersCount.asPages(pageSize).flatMap { page ->
     val activePrisoners = getActivePrisonersForPage(page)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/incentives/IncentivesReconciliationService.kt
@@ -27,6 +27,25 @@ class IncentivesReconciliationService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  suspend fun generateIncentiveReconciliationReport() {
+    val activePrisonersCount = nomisApiService.getActivePrisoners(0, 1).totalElements
+
+    telemetryClient.trackEvent("incentives-reports-reconciliation-requested", mapOf("active-prisoners" to activePrisonersCount.toString()))
+    log.info("Incentives reconciliation report requested for $activePrisonersCount active prisoners")
+
+    runCatching { generateReconciliationReport(activePrisonersCount) }
+      .onSuccess {
+        log.info("Incentives reconciliation report completed with ${it.size} mismatches")
+        telemetryClient.trackEvent("incentives-reports-reconciliation-report", mapOf("mismatch-count" to it.size.toString(), "success" to "true") + it.asMap())
+      }
+      .onFailure {
+        telemetryClient.trackEvent("incentives-reports-reconciliation-report", mapOf("success" to "false"))
+        log.error("Incentives reconciliation report failed", it)
+      }
+  }
+
+  private fun List<MismatchIncentiveLevel>.asMap(): Map<String, String> = this.associate { it.prisonerId.offenderNo to ("${it.nomisIncentiveLevel}:${it.dpsIncentiveLevel}") }
+
   suspend fun generateReconciliationReport(activePrisonersCount: Long): List<MismatchIncentiveLevel> = activePrisonersCount.asPages(pageSize).flatMap { page ->
     val activePrisoners = getActivePrisonersForPage(page)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManagerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/batch/BatchManagerTest.kt
@@ -25,12 +25,21 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.ATTEND
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.CASE_NOTES_ACTIVE_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.CASE_NOTES_FULL_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.CONTACT_PERSON_PROFILE_DETAILS_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.COURT_CASE_PRISONER_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.CSIP_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.DELETE_UNKNOWN_ACTIVITY_MAPPINGS
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.INCENTIVES_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.PERSON_CONTACT_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.PRISONER_CONTACT_RECON
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.PRISONER_RESTRICTION_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.PURGE_ACTIVITY_DLQ
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.batch.BatchType.SUSPENDED_ALLOCATION_RECON
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.casenotes.CaseNotesReconciliationService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.courtsentencing.CourtSentencingReconciliationService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.csip.CSIPReconciliationService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.incentives.IncentivesReconciliationService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.personalrelationships.ContactPersonReconciliationService
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.personalrelationships.PrisonerRestrictionsReconciliationService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.personalrelationships.profiledetails.ContactPersonProfileDetailsReconciliationService
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
@@ -44,7 +53,11 @@ class BatchManagerTest {
   private val caseNotesReconciliationService = mock<CaseNotesReconciliationService>()
   private val contactPersonProfileDetailsReconService = mock<ContactPersonProfileDetailsReconciliationService>()
   private val contactPersonReconService = mock<ContactPersonReconciliationService>()
+  private val courtSentencingReconciliationService = mock<CourtSentencingReconciliationService>()
+  private val csipReconciliationService = mock<CSIPReconciliationService>()
   private val hmppsQueueService = mock<HmppsQueueService>()
+  private val incentivesReconciliationService = mock<IncentivesReconciliationService>()
+  private val prisonerRestrictionsReconciliationService = mock<PrisonerRestrictionsReconciliationService>()
   private val schedulesService = mock<SchedulesService>()
   private val activityDlqName = "activity-dlq-name"
   private val event = mock<ContextRefreshedEvent>()
@@ -136,6 +149,26 @@ class BatchManagerTest {
   }
 
   @Test
+  fun `should call the prisoner court cases reconciliation service`() = runTest {
+    val batchManager = batchManager(COURT_CASE_PRISONER_RECON)
+
+    batchManager.onApplicationEvent(event)
+
+    verify(courtSentencingReconciliationService).generateCourtCasePrisonerReconciliationReportBatch()
+    verify(context).close()
+  }
+
+  @Test
+  fun `should call the csip reconciliation service`() = runTest {
+    val batchManager = batchManager(CSIP_RECON)
+
+    batchManager.onApplicationEvent(event)
+
+    verify(csipReconciliationService).generateCSIPReconciliationReport()
+    verify(context).close()
+  }
+
+  @Test
   fun `should call the delete unknown activity mappings service`() = runTest {
     val batchManager = batchManager(DELETE_UNKNOWN_ACTIVITY_MAPPINGS)
 
@@ -146,12 +179,42 @@ class BatchManagerTest {
   }
 
   @Test
+  fun `should call the incentives reconciliation service`() = runTest {
+    val batchManager = batchManager(INCENTIVES_RECON)
+
+    batchManager.onApplicationEvent(event)
+
+    verify(incentivesReconciliationService).generateIncentiveReconciliationReport()
+    verify(context).close()
+  }
+
+  @Test
   fun `should call the person contact reconciliation service`() = runTest {
     val batchManager = batchManager(PERSON_CONTACT_RECON)
 
     batchManager.onApplicationEvent(event)
 
     verify(contactPersonReconService).generatePersonContactReconciliationReportBatch()
+    verify(context).close()
+  }
+
+  @Test
+  fun `should call the prisoner contact reconciliation service`() = runTest {
+    val batchManager = batchManager(PRISONER_CONTACT_RECON)
+
+    batchManager.onApplicationEvent(event)
+
+    verify(contactPersonReconService).generatePrisonerContactReconciliationReportBatch()
+    verify(context).close()
+  }
+
+  @Test
+  fun `should call the prisoner restrictions reconciliation service`() = runTest {
+    val batchManager = batchManager(PRISONER_RESTRICTION_RECON)
+
+    batchManager.onApplicationEvent(event)
+
+    verify(prisonerRestrictionsReconciliationService).generatePrisonerRestrictionsReconciliationReportBatch()
     verify(context).close()
   }
 
@@ -188,7 +251,11 @@ class BatchManagerTest {
     caseNotesReconciliationService,
     contactPersonProfileDetailsReconService,
     contactPersonReconService,
+    courtSentencingReconciliationService,
+    csipReconciliationService,
     hmppsQueueService,
+    incentivesReconciliationService,
+    prisonerRestrictionsReconciliationService,
     schedulesService,
   )
 }


### PR DESCRIPTION
This is for court case prisoners, CSIP, incentives, prisoner contacts and prisoner restrictions. If each is successful in preprod then they will replace the reconciliations in prod and the unsecured endpoints will be removed.