### PR TITLE
SDIT-3671 Prevent sync back to NOMIS of visit deletes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/officialvisits/OfficialVisitsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/officialvisits/OfficialVisitsService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Up
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateOfficialVisitorRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.MappingRetry.MappingTypes.OFFICIAL_VISIT
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.MappingRetry.MappingTypes.OFFICIAL_VISITOR
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.didOriginateInDPS
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.model.AttendanceType
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.model.SearchLevelType
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.model.SyncOfficialVisit
@@ -25,6 +26,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.synchronise
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.track
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.tryFetchParent
 import java.time.LocalTime
+import kotlin.collections.plus
 
 @Service
 class OfficialVisitsService(
@@ -176,18 +178,23 @@ class OfficialVisitsService(
 
   suspend fun visitDeleted(event: VisitEvent) {
     val telemetry = event.asTelemetry()
-    val visitMapping = mappingApiService.getVisitByDpsIdOrNull(
-      dpsVisitId = event.additionalInformation.officialVisitId,
-    )?.also {
-      telemetry["nomisVisitId"] = it.nomisId.toString()
-    }
 
-    if (visitMapping != null) {
-      track("${OFFICIAL_VISIT.entityName}-delete", telemetry) {
-        nomisApiService.deleteOfficialVisit(
-          visitId = visitMapping.nomisId,
-        )
-        mappingApiService.deleteByVisitNomisId(visitMapping.nomisId)
+    if (event.didOriginateInDPS()) {
+      val visitMapping = mappingApiService.getVisitByDpsIdOrNull(
+        dpsVisitId = event.additionalInformation.officialVisitId,
+      )?.also {
+        telemetry["nomisVisitId"] = it.nomisId.toString()
+      }
+
+      if (visitMapping != null) {
+        track("${OFFICIAL_VISIT.entityName}-delete", telemetry) {
+          nomisApiService.deleteOfficialVisit(
+            visitId = visitMapping.nomisId,
+          )
+          mappingApiService.deleteByVisitNomisId(visitMapping.nomisId)
+        }
+      } else {
+        telemetryClient.trackEvent("${OFFICIAL_VISIT.entityName}-delete-ignored", telemetry + ("reason" to "Visit mapping not found"))
       }
     } else {
       telemetryClient.trackEvent("${OFFICIAL_VISIT.entityName}-delete-ignored", telemetry)
@@ -272,24 +279,28 @@ class OfficialVisitsService(
   }
   suspend fun visitorDeleted(event: VisitorEvent) {
     val telemetry = event.asTelemetry()
-    val visitMapping = mappingApiService.getVisitByDpsIdOrNull(
-      dpsVisitId = event.additionalInformation.officialVisitId,
-    )?.also {
-      telemetry["nomisVisitId"] = it.nomisId.toString()
-    }
-    val visitorMapping = mappingApiService.getVisitorByDpsIdOrNull(
-      dpsVisitorId = event.additionalInformation.officialVisitorId,
-    )?.also {
-      telemetry["nomisVisitorId"] = it.nomisId.toString()
-    }
+    if (event.didOriginateInDPS()) {
+      val visitMapping = mappingApiService.getVisitByDpsIdOrNull(
+        dpsVisitId = event.additionalInformation.officialVisitId,
+      )?.also {
+        telemetry["nomisVisitId"] = it.nomisId.toString()
+      }
+      val visitorMapping = mappingApiService.getVisitorByDpsIdOrNull(
+        dpsVisitorId = event.additionalInformation.officialVisitorId,
+      )?.also {
+        telemetry["nomisVisitorId"] = it.nomisId.toString()
+      }
 
-    if (visitMapping != null && visitorMapping != null) {
-      track("${OFFICIAL_VISITOR.entityName}-delete", telemetry) {
-        nomisApiService.deleteOfficialVisitor(
-          visitId = visitMapping.nomisId,
-          visitorId = visitorMapping.nomisId,
-        )
-        mappingApiService.deleteByVisitorNomisId(visitorMapping.nomisId)
+      if (visitMapping != null && visitorMapping != null) {
+        track("${OFFICIAL_VISITOR.entityName}-delete", telemetry) {
+          nomisApiService.deleteOfficialVisitor(
+            visitId = visitMapping.nomisId,
+            visitorId = visitorMapping.nomisId,
+          )
+          mappingApiService.deleteByVisitorNomisId(visitorMapping.nomisId)
+        }
+      } else {
+        telemetryClient.trackEvent("${OFFICIAL_VISITOR.entityName}-delete-ignored", telemetry + ("reason" to "Visit or visitor mapping not found"))
       }
     } else {
       telemetryClient.trackEvent("${OFFICIAL_VISITOR.entityName}-delete-ignored", telemetry)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/officialvisits/OfficialVisitsToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/officialvisits/OfficialVisitsToNomisIntTest.kt
@@ -463,6 +463,29 @@ class OfficialVisitsToNomisIntTest(
     val nomisVisitId = 92492L
 
     @Nested
+    @DisplayName("when NOMIS is the origin of a official visit delete")
+    inner class WhenNomisDeleted {
+      @BeforeEach
+      fun setUp() {
+        publishDeleteOfficialVisitDomainEvent(officialVisitId = dpsOfficialVisitId.toString(), prisonId = prisonId, offenderNo = offenderNo, source = "NOMIS")
+        waitForAnyProcessingToComplete()
+      }
+
+      @Test
+      fun `will send telemetry event showing the delete is ignored`() {
+        verify(telemetryClient).trackEvent(
+          eq("official-visit-delete-ignored"),
+          check {
+            assertThat(it["dpsOfficialVisitId"]).isEqualTo(dpsOfficialVisitId.toString())
+            assertThat(it["offenderNo"]).isEqualTo(offenderNo)
+            assertThat(it["prisonId"]).isEqualTo(prisonId)
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
     @DisplayName("when visit mapping does not exist")
     inner class WhenVisitMappingDoesNotExists {
 
@@ -481,6 +504,7 @@ class OfficialVisitsToNomisIntTest(
             assertThat(it["dpsOfficialVisitId"]).isEqualTo(dpsOfficialVisitId.toString())
             assertThat(it["offenderNo"]).isEqualTo(offenderNo)
             assertThat(it["prisonId"]).isEqualTo(prisonId)
+            assertThat(it["reason"]).isEqualTo("Visit mapping not found")
           },
           isNull(),
         )
@@ -903,6 +927,30 @@ class OfficialVisitsToNomisIntTest(
     val prisonId = "MDI"
 
     @Nested
+    @DisplayName("when NOMIS is the origin of a official visitor delete")
+    inner class WhenNomisDeleted {
+      @BeforeEach
+      fun setUp() {
+        publishDeleteOfficialVisitorDomainEvent(officialVisitorId = dpsOfficialVisitorId.toString(), officialVisitId = dpsOfficialVisitId.toString(), prisonId = prisonId, contactId = contactAndPersonId.toString(), source = "DPS")
+        waitForAnyProcessingToComplete()
+      }
+
+      @Test
+      fun `will send telemetry event showing the delete ignored`() {
+        verify(telemetryClient).trackEvent(
+          eq("official-visitor-delete-ignored"),
+          check {
+            assertThat(it["dpsOfficialVisitorId"]).isEqualTo(dpsOfficialVisitorId.toString())
+            assertThat(it["dpsOfficialVisitId"]).isEqualTo(dpsOfficialVisitId.toString())
+            assertThat(it["dpsContactId"]).isEqualTo(contactAndPersonId.toString())
+            assertThat(it["prisonId"]).isEqualTo(prisonId)
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
     @DisplayName("when visitor mapping does not exists")
     inner class WhenVisitorMappingDoesNotExists {
 
@@ -915,7 +963,7 @@ class OfficialVisitsToNomisIntTest(
       }
 
       @Test
-      fun `will send telemetry event showing the create`() {
+      fun `will send telemetry event showing the delete ignored`() {
         verify(telemetryClient).trackEvent(
           eq("official-visitor-delete-ignored"),
           check {
@@ -924,6 +972,7 @@ class OfficialVisitsToNomisIntTest(
             assertThat(it["nomisVisitId"]).isEqualTo(nomisVisitId.toString())
             assertThat(it["dpsContactId"]).isEqualTo(contactAndPersonId.toString())
             assertThat(it["prisonId"]).isEqualTo(prisonId)
+            assertThat(it["reason"]).isEqualTo("Visit or visitor mapping not found")
           },
           isNull(),
         )


### PR DESCRIPTION
Normally sync'ng back to NOMIS a delete when a mapping still exists is fine. But for visits it isn't since the delete from DPS might be a NOMIS social visit that was converted from an Official Visit