### PR TITLE
SDIT-2832 Refactor - split tests and move to tap package

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapActivePrisonersReconciliationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapActivePrisonersReconciliationIntTest.kt
@@ -28,19 +28,18 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMove
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsDpsApiMockServer.Companion.reconMovement
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsDpsApiMockServer.Companion.reconOccurrence
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsMappingApiMockServer
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.absence
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.application
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.scheduledAbsence
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.scheduledAbsenceReturn
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsence
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsenceReturn
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.Location
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.PersonTapDetail
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.ReconciliationMovement.Direction.IN
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.ReconciliationMovement.Direction.OUT
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.ReconciliationOccurrence
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.ReconciliationOccurrence.StatusCode.SCHEDULED
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.absence
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.application
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.scheduledAbsence
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.scheduledAbsenceReturn
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsence
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsenceReturn
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.ExternalMovementMappingIdsDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.ScheduledMovementMappingIdsDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.TemporaryAbsenceApplicationMappingIdsDto
@@ -55,7 +54,7 @@ import java.util.*
 
 class TapActivePrisonersReconciliationIntTest(
   @Autowired private val reconciliationService: TemporaryAbsencesActivePrisonersReconciliationService,
-  @Autowired private val nomisMovementsApi: ExternalMovementsNomisApiMockServer,
+  @Autowired private val nomisMovementsApi: TapNomisApiMockServer,
   @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
 ) : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapAllPrisonersReconciliationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapAllPrisonersReconciliationIntTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMove
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsDpsApiMockServer.Companion.reconMovement
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsDpsApiMockServer.Companion.reconOccurrence
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsMappingApiMockServer
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.MovementInOutCount
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.PersonAuthorisationCount
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.PersonMovementsCount
@@ -45,12 +44,12 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Of
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ScheduledOut
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.NomisApiExtension
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.generateOffenderNo
-import java.util.UUID
+import java.util.*
 import kotlin.random.Random
 
 class TapAllPrisonersReconciliationIntTest(
   @Autowired private val reconciliationService: TemporaryAbsencesAllPrisonersReconciliationService,
-  @Autowired private val nomisApi: ExternalMovementsNomisApiMockServer,
+  @Autowired private val nomisApi: TapNomisApiMockServer,
   @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
 ) : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapAuthorisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapAuthorisationIntTest.kt
@@ -1,0 +1,719 @@
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps
+
+import com.github.tomakehurst.wiremock.client.WireMock.absent
+import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.equalToDateTime
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NOT_FOUND
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.integration.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsDpsApiExtension.Companion.dpsExternalMovementsServer
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsDpsApiMockServer
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsMappingApiMockServer
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.upsertTemporaryAbsenceApplicationResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.temporaryAbsenceScheduledMovementMapping
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.DuplicateErrorContentObject
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.DuplicateMappingErrorResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.TemporaryAbsenceApplicationSyncMappingDto
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.withRequestBodyJsonPath
+import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
+import java.time.LocalDateTime
+import java.util.*
+
+class TapAuthorisationIntTest : SqsIntegrationTestBase() {
+
+  @Autowired
+  private lateinit var nomisApi: TapNomisApiMockServer
+
+  @Autowired
+  private lateinit var mappingApi: ExternalMovementsMappingApiMockServer
+
+  private val dpsApi: ExternalMovementsDpsApiMockServer = dpsExternalMovementsServer
+
+  private val today = LocalDateTime.now()
+  private val tomorrow = today.plusDays(1)
+
+  @Nested
+  @DisplayName("person.temporary-absence-authorisation.approved (created)")
+  inner class TapApplicationCreated {
+    private val prisonerNumber = "A1234BC"
+    private val dpsId = UUID.randomUUID()
+    private val nomisId = 56789L
+
+    @Nested
+    @DisplayName("when NOMIS is the origin of an authorisation approval")
+    inner class WhenNomisCreated {
+
+      @BeforeEach
+      fun setUp() {
+        publishAuthorisationDomainEvent(dpsAuthorisationId = dpsId, prisonerNumber = prisonerNumber, source = "NOMIS")
+        waitForAnyProcessingToComplete()
+      }
+
+      @Test
+      fun `will send telemetry event showing the ignore`() {
+        verify(telemetryClient).trackEvent(
+          eq("temporary-absence-application-create-ignored"),
+          any(),
+          isNull(),
+        )
+      }
+
+      @Test
+      fun `will NOT create the application in NOMIS`() {
+        nomisApi.verify(0, putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")))
+      }
+
+      @Test
+      fun `will NOT create any mappings`() {
+        mappingApi.verify(0, postRequestedFor(urlEqualTo("/mapping/temporary-absence/application")))
+      }
+    }
+
+    @Nested
+    @DisplayName("when DPS is the origin of an authorisation approval")
+    inner class WhenDpsCreated {
+      @Nested
+      @DisplayName("when all goes ok")
+      inner class HappyPath {
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, status = NOT_FOUND)
+          dpsApi.stubGetTapAuthorisation(id = dpsId, response = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 0, startTime = today, endTime = tomorrow))
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+          mappingApi.stubCreateTemporaryAbsenceApplicationMapping()
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+          waitForAnyProcessingToComplete()
+        }
+
+        @Test
+        fun `will send telemetry event showing the create`() {
+          verify(telemetryClient).trackEvent(
+            eq("temporary-absence-application-create-success"),
+            any(),
+            isNull(),
+          )
+        }
+
+        @Test
+        fun `will check if the application mapping exists`() {
+          mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/application/dps-id/$dpsId")))
+        }
+
+        @Test
+        fun `telemetry will contain key facts about the application created`() {
+          verify(telemetryClient).trackEvent(
+            eq("temporary-absence-application-create-success"),
+            check {
+              assertThat(it).containsEntry("dpsAuthorisationId", dpsId.toString())
+              assertThat(it).containsEntry("nomisApplicationId", nomisId.toString())
+              assertThat(it).containsEntry("offenderNo", prisonerNumber)
+              assertThat(it).containsEntry("bookingId", "12345")
+            },
+            isNull(),
+          )
+        }
+
+        @Test
+        fun `will call back to DPS to get authorisation details`() {
+          dpsApi.verify(getRequestedFor(urlEqualTo("/sync/temporary-absence-authorisations/$dpsId")))
+        }
+
+        @Test
+        fun `will create the application in NOMIS`() {
+          nomisApi.verify(putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")))
+        }
+
+        @Test
+        fun `the created application will contain correct details`() {
+          nomisApi.verify(
+            putRequestedFor(anyUrl())
+              .withRequestBodyJsonPath("eventSubType", "R2")
+              .withRequestBodyJsonPath("fromDate", today.toLocalDate())
+              .withRequestBodyJsonPath("toDate", tomorrow.toLocalDate())
+              .withRequestBodyJsonPath("comment", "Some notes")
+              .withRequestBodyJsonPath("temporaryAbsenceType", "SR")
+              .withRequestBodyJsonPath("temporaryAbsenceSubType", "RDR")
+              .withRequestBodyJsonPath("transportType", "VAN"),
+          )
+        }
+
+        @Test
+        fun `will create a mapping between the NOMIS and DPS ids`() {
+          mappingApi.verify(
+            postRequestedFor(urlEqualTo("/mapping/temporary-absence/application"))
+              .withRequestBodyJsonPath("dpsMovementApplicationId", "$dpsId")
+              .withRequestBodyJsonPath("nomisMovementApplicationId", "$nomisId")
+              .withRequestBodyJsonPath("prisonerNumber", "A1234BC")
+              .withRequestBodyJsonPath("bookingId", "12345")
+              .withRequestBodyJsonPath("mappingType", "DPS_CREATED"),
+          )
+        }
+      }
+
+      @Nested
+      @DisplayName("when mapping service fails once")
+      inner class MappingFailure {
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, status = NOT_FOUND)
+          dpsApi.stubGetTapAuthorisation(dpsId)
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+          mappingApi.stubCreateTemporaryAbsenceApplicationMappingFailureFollowedBySuccess()
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+        }
+
+        @Test
+        fun `will send telemetry for initial mapping failure`() {
+          await untilAsserted {
+            verify(telemetryClient).trackEvent(
+              eq("temporary-absence-application-mapping-create-error"),
+              check {
+                assertThat(it).containsEntry("error", "500 Internal Server Error from POST http://localhost:8084/mapping/temporary-absence/application")
+              },
+              isNull(),
+            )
+          }
+        }
+
+        @Test
+        fun `will send telemetry for application create`() {
+          await untilAsserted {
+            verify(telemetryClient).trackEvent(
+              eq("temporary-absence-application-create-success"),
+              any(),
+              isNull(),
+            )
+          }
+        }
+
+        @Test
+        fun `will create the application in NOMIS once`() {
+          await untilAsserted {
+            nomisApi.verify(1, putRequestedFor(urlEqualTo("/movements/A1234BC/temporary-absences/application")))
+          }
+        }
+      }
+
+      @Nested
+      @DisplayName("when mapping service detects a duplicate mapping")
+      inner class DuplicateMappingFailure {
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, NOT_FOUND)
+          dpsApi.stubGetTapAuthorisation(dpsId)
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+          mappingApi.stubCreateTemporaryAbsenceApplicationMappingConflict(
+            error = DuplicateMappingErrorResponse(
+              moreInfo = DuplicateErrorContentObject(
+                existing = TemporaryAbsenceApplicationSyncMappingDto(
+                  prisonerNumber = "A1234BC",
+                  bookingId = 12345L,
+                  nomisMovementApplicationId = nomisId,
+                  dpsMovementApplicationId = dpsId,
+                  mappingType = TemporaryAbsenceApplicationSyncMappingDto.MappingType.NOMIS_CREATED,
+                ),
+                duplicate = TemporaryAbsenceApplicationSyncMappingDto(
+                  prisonerNumber = "A1234BC",
+                  bookingId = 12345L,
+                  nomisMovementApplicationId = nomisId + 1,
+                  dpsMovementApplicationId = dpsId,
+                  mappingType = TemporaryAbsenceApplicationSyncMappingDto.MappingType.NOMIS_CREATED,
+                ),
+              ),
+              errorCode = 1409,
+              status = DuplicateMappingErrorResponse.Status._409_CONFLICT,
+              userMessage = "Duplicate mapping",
+            ),
+          )
+
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+        }
+
+        @Test
+        fun `will send telemetry for duplicate`() {
+          await untilAsserted {
+            verify(telemetryClient).trackEvent(
+              eq("to-nomis-synch-temporary-absence-application-duplicate"),
+              any(),
+              isNull(),
+            )
+          }
+        }
+
+        @Test
+        fun `will create the application in NOMIS once`() {
+          await untilAsserted {
+            verify(telemetryClient).trackEvent(
+              eq("to-nomis-synch-temporary-absence-application-duplicate"),
+              any(),
+              isNull(),
+            )
+            nomisApi.verify(1, putRequestedFor(urlEqualTo("/movements/A1234BC/temporary-absences/application")))
+          }
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("when we receive a relocated event for a new authorisation")
+    inner class IgnoreRelocatedEventType {
+
+      @BeforeEach
+      fun setUp() {
+        mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, status = NOT_FOUND)
+
+        publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS", "person.temporary-absence-authorisation.relocated")
+        waitForAnyProcessingToComplete()
+      }
+
+      @Test
+      fun `will check if the application mapping exists`() {
+        mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/application/dps-id/$dpsId")))
+      }
+
+      @Test
+      fun `will send telemetry event showing the create was ignored`() {
+        verify(telemetryClient).trackEvent(
+          eq("temporary-absence-application-create-ignored"),
+          check {
+            assertThat(it).containsEntry("dpsAuthorisationId", dpsId.toString())
+            assertThat(it).containsEntry("offenderNo", prisonerNumber)
+            assertThat(it).containsEntry("reason", "This event is applied to updates only")
+          },
+          isNull(),
+        )
+      }
+
+      @Test
+      fun `will NOT create the application in NOMIS once`() {
+        await untilAsserted {
+          nomisApi.verify(0, putRequestedFor(urlEqualTo("/movements/A1234BC/temporary-absences/application")))
+        }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("person.temporary-absence-authorisation.approved (updated)")
+  inner class TapApplicationUpdated {
+    private val prisonerNumber = "A1234BC"
+    private val dpsId = UUID.randomUUID()
+    private val nomisId = 56789L
+
+    @Nested
+    @DisplayName("when NOMIS is the origin of an authorisation approval")
+    inner class WhenNomisUpdated {
+
+      @BeforeEach
+      fun setUp() {
+        publishAuthorisationDomainEvent(dpsAuthorisationId = dpsId, prisonerNumber = prisonerNumber, source = "NOMIS")
+        waitForAnyProcessingToComplete()
+      }
+
+      @Test
+      fun `will send telemetry event showing the ignore`() {
+        verify(telemetryClient).trackEvent(
+          eq("temporary-absence-application-create-ignored"),
+          any(),
+          isNull(),
+        )
+      }
+
+      @Test
+      fun `will NOT create the application in NOMIS`() {
+        nomisApi.verify(0, putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")))
+      }
+
+      @Test
+      fun `will NOT create any mappings`() {
+        mappingApi.verify(0, postRequestedFor(urlEqualTo("/mapping/temporary-absence/application")))
+      }
+    }
+
+    @Nested
+    @DisplayName("when DPS is the origin of an authorisation approval")
+    inner class WhenDpsCreated {
+      @Nested
+      @DisplayName("when all goes ok")
+      inner class HappyPath {
+        private val startTime = today
+        private val endTime = today.plusHours(1)
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
+          dpsApi.stubGetTapAuthorisation(dpsId, response = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 0, startTime = startTime, endTime = endTime))
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+          waitForAnyProcessingToComplete()
+        }
+
+        @Test
+        fun `will send telemetry event showing the update`() {
+          verify(telemetryClient).trackEvent(
+            eq("temporary-absence-application-update-success"),
+            any(),
+            isNull(),
+          )
+        }
+
+        @Test
+        fun `will check if the application mapping exists`() {
+          mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/application/dps-id/$dpsId")))
+        }
+
+        @Test
+        fun `telemetry will contain key facts about the application updated`() {
+          verify(telemetryClient).trackEvent(
+            eq("temporary-absence-application-update-success"),
+            check {
+              assertThat(it).containsEntry("dpsAuthorisationId", dpsId.toString())
+              assertThat(it).containsEntry("nomisApplicationId", nomisId.toString())
+              assertThat(it).containsEntry("offenderNo", prisonerNumber)
+              assertThat(it).containsEntry("bookingId", "12345")
+            },
+            isNull(),
+          )
+        }
+
+        @Test
+        fun `will call back to DPS to get authorisation details`() {
+          dpsApi.verify(getRequestedFor(urlEqualTo("/sync/temporary-absence-authorisations/$dpsId")))
+        }
+
+        @Test
+        fun `will update the application in NOMIS`() {
+          nomisApi.verify(
+            putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application"))
+              .withRequestBodyJsonPath("escortCode", "U"),
+          )
+        }
+
+        @Test
+        fun `the updated application will contain correct details`() {
+          nomisApi.verify(
+            putRequestedFor(anyUrl())
+              .withRequestBodyJsonPath("eventSubType", "R2")
+              .withRequestBodyJsonPath("fromDate", startTime.toLocalDate())
+              .withRequestBodyJsonPath("toDate", endTime.toLocalDate())
+              .withRequestBodyJsonPath("releaseTime", equalToDateTime(startTime.toLocalDate().atStartOfDay()))
+              .withRequestBodyJsonPath("returnTime", equalToDateTime(endTime.plusDays(1).toLocalDate().atStartOfDay().minusMinutes(1)))
+              .withRequestBodyJsonPath("comment", "Some notes")
+              .withRequestBodyJsonPath("temporaryAbsenceType", "SR")
+              .withRequestBodyJsonPath("temporaryAbsenceSubType", "RDR")
+              .withRequestBodyJsonPath("transportType", "VAN")
+              // Address is only updated when the application update is triggered by synchronising the DPS occurrence
+              .withRequestBodyJsonPath("toAddress", absent()),
+          )
+        }
+      }
+
+      @Nested
+      @DisplayName("when all goes ok for a single schedule")
+      inner class HappyPathWithSingleSchedule {
+        private val startTime = today
+        private val endTime = today.plusHours(1)
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
+          dpsApi.stubGetTapAuthorisation(id = dpsId, response = dpsApi.tapAuthorisation(id = dpsId, repeat = false, occurrenceCount = 1, startTime = startTime, endTime = endTime))
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+          waitForAnyProcessingToComplete()
+        }
+
+        @Test
+        fun `the updated application's start and end times to match occurrences`() {
+          nomisApi.verify(
+            putRequestedFor(anyUrl())
+              .withRequestBodyJsonPath("fromDate", "${startTime.toLocalDate()}")
+              .withRequestBodyJsonPath("toDate", "${endTime.toLocalDate()}")
+              .withRequestBodyJsonPath("releaseTime", equalToDateTime(startTime))
+              .withRequestBodyJsonPath("returnTime", equalToDateTime(endTime)),
+          )
+        }
+      }
+
+      @Nested
+      @DisplayName("when all goes ok for multiple schedules")
+      inner class HappyPathWithMultipleSchedules {
+        private val startTime = today
+        private val endTime = tomorrow.plusDays(1)
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
+          dpsApi.stubGetTapAuthorisation(id = dpsId, response = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 2, startTime = startTime, endTime = endTime))
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+          waitForAnyProcessingToComplete()
+        }
+
+        @Test
+        fun `the updated application's start and end times to match occurrences`() {
+          nomisApi.verify(
+            putRequestedFor(anyUrl())
+              .withRequestBodyJsonPath("fromDate", "${startTime.toLocalDate()}")
+              .withRequestBodyJsonPath("toDate", "${endTime.toLocalDate()}")
+              .withRequestBodyJsonPath("releaseTime", equalToDateTime(startTime.toLocalDate().atStartOfDay()))
+              .withRequestBodyJsonPath("returnTime", equalToDateTime(endTime.plusDays(1).toLocalDate().atStartOfDay().minusMinutes(1))),
+          )
+        }
+
+        @Test
+        fun `all occurrence addresses are sent to NOMIS`() {
+          nomisApi.verify(
+            putRequestedFor(anyUrl())
+              .withRequestBodyJsonPath("toAddresses.length()", 2)
+              .withRequestBodyJsonPath("toAddresses[0].addressText", "some address 1")
+              .withRequestBodyJsonPath("toAddresses[0].name", "some description 1")
+              .withRequestBodyJsonPath("toAddresses[0].postalCode", "some postcode 1")
+              .withRequestBodyJsonPath("toAddresses[1].addressText", "some address 2")
+              .withRequestBodyJsonPath("toAddresses[1].name", "some description 2")
+              .withRequestBodyJsonPath("toAddresses[1].postalCode", "some postcode 2"),
+          )
+        }
+      }
+
+      @Nested
+      @DisplayName("when there are multiple schedules with the same NOMIS address")
+      inner class MultipleSchedulesWithSameNomisAddress {
+        private val startTime = today
+        private val endTime = tomorrow.plusDays(1)
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
+          val authorisation = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 3, startTime = startTime, endTime = endTime)
+          dpsApi.stubGetTapAuthorisation(id = dpsId, response = authorisation)
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+          // Create a stub for the first schedule mapping only (which is same as third schedule)
+          with(authorisation.occurrences[0]) {
+            mappingApi.stubGetTemporaryAbsenceScheduledMovementMapping(
+              dpsId = id,
+              mapping = temporaryAbsenceScheduledMovementMapping().copy(
+                prisonerNumber = prisonerNumber,
+                dpsOccurrenceId = id,
+                nomisAddressId = 1,
+                dpsDescription = "some description 1",
+                dpsAddressText = "some address 1",
+                dpsPostcode = "some postcode 1",
+              ),
+            )
+          }
+
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+          waitForAnyProcessingToComplete()
+        }
+
+        @Test
+        fun `we get the occurrence mappings for the 2 unique addresses`() {
+          mappingApi.verify(
+            2,
+            getRequestedFor(urlMatching("/mapping/temporary-absence/scheduled-movement/dps-id/.*")),
+          )
+        }
+
+        @Test
+        fun `the updated application's locations contain the NOMIS address IDs from the occurrence mappings`() {
+          nomisApi.verify(
+            putRequestedFor(anyUrl())
+              .withRequestBodyJsonPath("toAddresses.length()", 2)
+              // we found the existing NOMIS address
+              .withRequestBodyJsonPath("toAddresses[0].id", 1)
+              .withRequestBodyJsonPath("toAddresses[0].addressText", absent())
+              // there is no NOMIS address so NOMIS will create a new one
+              .withRequestBodyJsonPath("toAddresses[1].id", absent())
+              .withRequestBodyJsonPath("toAddresses[1].name", "some description 2")
+              .withRequestBodyJsonPath("toAddresses[1].addressText", "some address 2")
+              .withRequestBodyJsonPath("toAddresses[1].postalCode", "some postcode 2"),
+          )
+        }
+      }
+
+      @Nested
+      @DisplayName("when all goes ok for zero schedules")
+      inner class HappyPathWithZeroSchedules {
+        private val startTime = today
+        private val endTime = tomorrow.plusDays(1)
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
+          dpsApi.stubGetTapAuthorisation(id = dpsId, response = dpsApi.tapAuthorisation(id = dpsId, repeat = false, occurrenceCount = 0, startTime = startTime, endTime = endTime, statusCode = "EXPIRED"))
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+          waitForAnyProcessingToComplete()
+        }
+
+        @Test
+        fun `the updated application's start and end times match DPS`() {
+          nomisApi.verify(
+            putRequestedFor(anyUrl())
+              .withRequestBodyJsonPath("applicationStatus", "PEN")
+              .withRequestBodyJsonPath("fromDate", "${startTime.toLocalDate()}")
+              .withRequestBodyJsonPath("toDate", "${endTime.toLocalDate()}")
+              .withRequestBodyJsonPath("releaseTime", equalToDateTime(startTime.toLocalDate().atStartOfDay()))
+              .withRequestBodyJsonPath("returnTime", equalToDateTime(endTime.plusDays(1).toLocalDate().atStartOfDay().minusMinutes(1))),
+          )
+        }
+      }
+
+      @Nested
+      @DisplayName("when we receive an update request for authorisation relocated")
+      inner class UpdateForRelocatedEventType {
+        private val startTime = today
+        private val endTime = today.plusHours(1)
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
+          dpsApi.stubGetTapAuthorisation(dpsId, response = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 0, startTime = startTime, endTime = endTime))
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
+
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS", "person.temporary-absence-authorisation.relocated")
+          waitForAnyProcessingToComplete()
+        }
+
+        @Test
+        fun `will send telemetry event showing the update`() {
+          verify(telemetryClient).trackEvent(
+            eq("temporary-absence-application-update-success"),
+            any(),
+            isNull(),
+          )
+        }
+
+        @Test
+        fun `will update the application in NOMIS`() {
+          nomisApi.verify(
+            putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")),
+          )
+        }
+      }
+
+      @Nested
+      inner class WhenNomisUpdateFails {
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
+          dpsApi.stubGetTapAuthorisation(dpsId)
+          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, HttpStatus.INTERNAL_SERVER_ERROR)
+          mappingApi.stubCreateTemporaryAbsenceApplicationMapping()
+
+          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
+          waitForAnyProcessingToComplete("temporary-absence-application-update-error")
+        }
+
+        @Test
+        fun `will check if the application mapping exists`() {
+          mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/application/dps-id/$dpsId")))
+        }
+
+        @Test
+        fun `telemetry will contain key facts about the application`() {
+          verify(telemetryClient).trackEvent(
+            eq("temporary-absence-application-update-error"),
+            check {
+              assertThat(it).containsEntry("dpsAuthorisationId", dpsId.toString())
+              assertThat(it).containsEntry("offenderNo", prisonerNumber)
+              assertThat(it).containsEntry("error", "500 Internal Server Error from PUT http://localhost:8082/movements/A1234BC/temporary-absences/application")
+            },
+            isNull(),
+          )
+        }
+
+        @Test
+        fun `will call back to DPS to get authorisation details`() {
+          dpsApi.verify(getRequestedFor(urlEqualTo("/sync/temporary-absence-authorisations/$dpsId")))
+        }
+
+        @Test
+        fun `will attempt to update the application in NOMIS`() {
+          nomisApi.verify(putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")))
+        }
+
+        @Test
+        fun `will put the message on the DLQ`() {
+          assertThat(movementsDlqClient!!.countAllMessagesOnQueue(movementsDlqUrl!!).get()).isEqualTo(1)
+        }
+      }
+    }
+  }
+
+  private fun publishAuthorisationDomainEvent(dpsAuthorisationId: UUID, prisonerNumber: String, source: String = "DPS", eventType: String = "person.temporary-absence-authorisation.approved") {
+    with(eventType) {
+      publishDomainEvent(eventType = this, payload = messagePayload(eventType = this, id = dpsAuthorisationId, prisonerNumber = prisonerNumber, source = source))
+    }
+  }
+
+  private fun publishDomainEvent(
+    eventType: String,
+    payload: String,
+  ) {
+    awsSnsClient.publish(
+      PublishRequest.builder().topicArn(topicArn)
+        .message(payload)
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String")
+              .stringValue(eventType).build(),
+          ),
+        ).build(),
+    ).get()
+  }
+  fun messagePayload(
+    eventType: String,
+    prisonerNumber: String,
+    id: UUID,
+    source: String,
+  ) = //language=JSON
+    """
+    {
+      "description":"Some event", 
+      "eventType":"$eventType", 
+      "additionalInformation": {
+        "id": "$id",
+        "source": "$source"
+      },
+      "personReference": {
+        "identifiers": [
+          {
+            "type": "NOMS",
+            "value": "$prisonerNumber"
+          }
+        ]
+      }
+    }
+    """
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiMockServer.kt
@@ -1,13 +1,6 @@
-package uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps
 
-import com.github.tomakehurst.wiremock.client.WireMock.aResponse
-import com.github.tomakehurst.wiremock.client.WireMock.delete
-import com.github.tomakehurst.wiremock.client.WireMock.get
-import com.github.tomakehurst.wiremock.client.WireMock.post
-import com.github.tomakehurst.wiremock.client.WireMock.put
-import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
-import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
-import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -37,13 +30,13 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Up
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpsertTemporaryAbsenceAddress
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpsertTemporaryAbsenceApplicationRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpsertTemporaryAbsenceApplicationResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.NomisApiExtension.Companion.nomisApi
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.NomisApiExtension
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Component
-class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
+class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
   companion object {
     private val now = LocalDateTime.now()
     private val today = now.toLocalDate()
@@ -337,10 +330,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     offenderNo: String = "A1234BC",
     response: UpsertTemporaryAbsenceApplicationResponse = upsertTemporaryAbsenceApplicationResponse(),
   ) {
-    nomisApi.stubFor(
-      put(urlEqualTo("/movements/$offenderNo/temporary-absences/application"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.put(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/application"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(HttpStatus.CREATED.value())
             .withBody(jsonMapper.writeValueAsString(response)),
@@ -353,10 +346,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
-    nomisApi.stubFor(
-      put(urlEqualTo("/movements/$offenderNo/temporary-absences/application"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.put(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/application"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
             .withBody(jsonMapper.writeValueAsString(error)),
@@ -368,10 +361,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     offenderNo: String = "A1234BC",
     response: UpsertScheduledTemporaryAbsenceResponse = upsertScheduledTemporaryAbsenceResponse(),
   ) {
-    nomisApi.stubFor(
-      put(urlEqualTo("/movements/$offenderNo/temporary-absences/scheduled-temporary-absence"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.put(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/scheduled-temporary-absence"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(HttpStatus.CREATED.value())
             .withBody(jsonMapper.writeValueAsString(response)),
@@ -384,10 +377,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
-    nomisApi.stubFor(
-      put(urlEqualTo("/movements/$offenderNo/temporary-absences/scheduled-temporary-absence"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.put(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/scheduled-temporary-absence"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
             .withBody(jsonMapper.writeValueAsString(error)),
@@ -399,10 +392,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     offenderNo: String = "A1234BC",
     response: CreateTemporaryAbsenceResponse = createTemporaryAbsenceResponse(),
   ) {
-    nomisApi.stubFor(
-      post(urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(HttpStatus.CREATED.value())
             .withBody(jsonMapper.writeValueAsString(response)),
@@ -415,10 +408,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
-    nomisApi.stubFor(
-      post(urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
             .withBody(jsonMapper.writeValueAsString(error)),
@@ -430,10 +423,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     offenderNo: String = "A1234BC",
     response: CreateTemporaryAbsenceReturnResponse = createTemporaryAbsenceReturnResponse(),
   ) {
-    nomisApi.stubFor(
-      post(urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence-return"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence-return"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(HttpStatus.CREATED.value())
             .withBody(jsonMapper.writeValueAsString(response)),
@@ -446,10 +439,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
-    nomisApi.stubFor(
-      post(urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence-return"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence-return"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
             .withBody(jsonMapper.writeValueAsString(error)),
@@ -461,10 +454,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     offenderNo: String = "A1234BC",
     response: OffenderTemporaryAbsenceSummaryResponse = createTemporaryAbsenceSummaryResponse(),
   ) {
-    nomisApi.stubFor(
-      get(urlEqualTo("/movements/$offenderNo/temporary-absences/summary"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/summary"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(HttpStatus.CREATED.value())
             .withBody(jsonMapper.writeValueAsString(response)),
@@ -477,10 +470,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
-    nomisApi.stubFor(
-      get(urlEqualTo("/movements/$offenderNo/temporary-absences/summary"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/summary"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
             .withBody(jsonMapper.writeValueAsString(error)),
@@ -492,10 +485,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     offenderNo: String = "A1234BC",
     response: OffenderTemporaryAbsenceIdsResponse = temporaryAbsenceSummaryIdsResponse(),
   ) {
-    nomisApi.stubFor(
-      get(urlEqualTo("/movements/$offenderNo/temporary-absences/ids"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/ids"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(HttpStatus.CREATED.value())
             .withBody(jsonMapper.writeValueAsString(response)),
@@ -508,10 +501,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
-    nomisApi.stubFor(
-      get(urlEqualTo("/movements/$offenderNo/temporary-absences/ids"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/ids"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
             .withBody(jsonMapper.writeValueAsString(error)),
@@ -523,10 +516,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     bookingId: Long = 12345L,
     response: BookingTemporaryAbsences = bookingTemporaryAbsences(bookingId = bookingId),
   ) {
-    nomisApi.stubFor(
-      get(urlEqualTo("/movements/booking/$bookingId/temporary-absences"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/movements/booking/$bookingId/temporary-absences"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(HttpStatus.OK.value())
             .withBody(jsonMapper.writeValueAsString(response)),
@@ -539,10 +532,10 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
-    nomisApi.stubFor(
-      get(urlEqualTo("/movements/booking/$bookingId/temporary-absences"))
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.get(WireMock.urlEqualTo("/movements/booking/$bookingId/temporary-absences"))
         .willReturn(
-          aResponse()
+          WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
             .withBody(jsonMapper.writeValueAsString(error)),
@@ -554,9 +547,9 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     offenderNo: String = "A1234BC",
     response: OffenderTemporaryAbsencesResponse = temporaryAbsencesResponse(),
   ) {
-    nomisApi.stubFor(
-      get(urlPathEqualTo("/movements/$offenderNo/temporary-absences")).willReturn(
-        aResponse()
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.get(WireMock.urlPathEqualTo("/movements/$offenderNo/temporary-absences")).willReturn(
+        WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(HttpStatus.OK.value())
           .withBody(jsonMapper.writeValueAsString(response)),
@@ -565,9 +558,9 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
   }
 
   fun stubGetTemporaryAbsences(status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
-    nomisApi.stubFor(
-      get(urlPathMatching("/movements/.*/temporary-absences")).willReturn(
-        aResponse()
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.get(WireMock.urlPathMatching("/movements/.*/temporary-absences")).willReturn(
+        WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
           .withBody(jsonMapper.writeValueAsString(error)),
@@ -579,12 +572,13 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     offenderNo: String = "A1234BC",
     eventId: Long = 4321L,
   ) {
-    nomisApi.stubFor(
-      delete(urlPathEqualTo("/movements/$offenderNo/temporary-absences/scheduled-temporary-absence/$eventId")).willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withStatus(HttpStatus.NO_CONTENT.value()),
-      ),
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.delete(WireMock.urlPathEqualTo("/movements/$offenderNo/temporary-absences/scheduled-temporary-absence/$eventId"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(HttpStatus.NO_CONTENT.value()),
+        ),
     )
   }
 
@@ -594,16 +588,17 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status = status.value()),
   ) {
-    nomisApi.stubFor(
-      delete(urlPathEqualTo("/movements/$offenderNo/temporary-absences/scheduled-temporary-absence/$eventId")).willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withStatus(status.value())
-          .withBody(jsonMapper.writeValueAsString(error)),
-      ),
+    NomisApiExtension.nomisApi.stubFor(
+      WireMock.delete(WireMock.urlPathEqualTo("/movements/$offenderNo/temporary-absences/scheduled-temporary-absence/$eventId"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status.value())
+            .withBody(jsonMapper.writeValueAsString(error)),
+        ),
     )
   }
 
-  fun verify(pattern: RequestPatternBuilder) = nomisApi.verify(pattern)
-  fun verify(count: Int, pattern: RequestPatternBuilder) = nomisApi.verify(count, pattern)
+  fun verify(pattern: RequestPatternBuilder) = NomisApiExtension.nomisApi.verify(pattern)
+  fun verify(count: Int, pattern: RequestPatternBuilder) = NomisApiExtension.nomisApi.verify(count, pattern)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiServiceTest.kt
@@ -20,17 +20,16 @@ import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.SpringAPIServiceTest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.createTemporaryAbsenceRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.createTemporaryAbsenceReturnRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.upsertScheduledTemporaryAbsenceRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.upsertTemporaryAbsenceApplicationRequest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.createTemporaryAbsenceRequest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.createTemporaryAbsenceReturnRequest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.upsertScheduledTemporaryAbsenceRequest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.upsertTemporaryAbsenceApplicationRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.RetryApiService
 
 @SpringAPIServiceTest
 @Import(
   TapNomisApiService::class,
-  ExternalMovementsNomisApiMockServer::class,
+  TapNomisApiMockServer::class,
   RetryApiService::class,
 )
 class TapNomisApiServiceTest {
@@ -38,7 +37,7 @@ class TapNomisApiServiceTest {
   private lateinit var apiService: TapNomisApiService
 
   @Autowired
-  private lateinit var mockServer: ExternalMovementsNomisApiMockServer
+  private lateinit var mockServer: TapNomisApiMockServer
 
   @Nested
   inner class TemporaryAbsenceApplication {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapOccurrenceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapOccurrenceIntTest.kt
@@ -1,14 +1,12 @@
-package uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements
+package uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps
 
 import com.github.tomakehurst.wiremock.client.WireMock.absent
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
 import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
-import com.github.tomakehurst.wiremock.client.WireMock.equalToDateTime
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
-import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
@@ -17,35 +15,35 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.eq
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.NOT_FOUND
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsDpsApiExtension.Companion.dpsExternalMovementsServer
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.upsertScheduledTemporaryAbsenceResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsNomisApiMockServer.Companion.upsertTemporaryAbsenceApplicationResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsDpsApiMockServer
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.ExternalMovementsMappingApiMockServer
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.Location
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.upsertScheduledTemporaryAbsenceResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.upsertTemporaryAbsenceApplicationResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.DuplicateErrorContentObject
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.DuplicateMappingErrorResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.ScheduledMovementSyncMappingDto
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.TemporaryAbsenceApplicationSyncMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.withRequestBodyJsonPath
 import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.time.LocalDateTime
 import java.util.*
 
-class ExternalMovementsToNomisIntTest : SqsIntegrationTestBase() {
+class TapOccurrenceIntTest : SqsIntegrationTestBase() {
 
   @Autowired
-  private lateinit var nomisApi: ExternalMovementsNomisApiMockServer
+  private lateinit var nomisApi: TapNomisApiMockServer
 
   @Autowired
   private lateinit var mappingApi: ExternalMovementsMappingApiMockServer
@@ -56,626 +54,8 @@ class ExternalMovementsToNomisIntTest : SqsIntegrationTestBase() {
   private val tomorrow = today.plusDays(1)
 
   @Nested
-  @DisplayName("person.temporary-absence-authorisation.approved (created)")
-  inner class TemporaryAbsenceApplicationCreated {
-    private val prisonerNumber = "A1234BC"
-    private val dpsId = UUID.randomUUID()
-    private val nomisId = 56789L
-
-    @Nested
-    @DisplayName("when NOMIS is the origin of an authorisation approval")
-    inner class WhenNomisCreated {
-
-      @BeforeEach
-      fun setUp() {
-        publishAuthorisationDomainEvent(dpsAuthorisationId = dpsId, prisonerNumber = prisonerNumber, source = "NOMIS")
-        waitForAnyProcessingToComplete()
-      }
-
-      @Test
-      fun `will send telemetry event showing the ignore`() {
-        verify(telemetryClient).trackEvent(
-          eq("temporary-absence-application-create-ignored"),
-          any(),
-          isNull(),
-        )
-      }
-
-      @Test
-      fun `will NOT create the application in NOMIS`() {
-        nomisApi.verify(0, putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")))
-      }
-
-      @Test
-      fun `will NOT create any mappings`() {
-        mappingApi.verify(0, postRequestedFor(urlEqualTo("/mapping/temporary-absence/application")))
-      }
-    }
-
-    @Nested
-    @DisplayName("when DPS is the origin of an authorisation approval")
-    inner class WhenDpsCreated {
-      @Nested
-      @DisplayName("when all goes ok")
-      inner class HappyPath {
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, status = NOT_FOUND)
-          dpsApi.stubGetTapAuthorisation(id = dpsId, response = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 0, startTime = today, endTime = tomorrow))
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-          mappingApi.stubCreateTemporaryAbsenceApplicationMapping()
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-          waitForAnyProcessingToComplete()
-        }
-
-        @Test
-        fun `will send telemetry event showing the create`() {
-          verify(telemetryClient).trackEvent(
-            eq("temporary-absence-application-create-success"),
-            any(),
-            isNull(),
-          )
-        }
-
-        @Test
-        fun `will check if the application mapping exists`() {
-          mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/application/dps-id/$dpsId")))
-        }
-
-        @Test
-        fun `telemetry will contain key facts about the application created`() {
-          verify(telemetryClient).trackEvent(
-            eq("temporary-absence-application-create-success"),
-            check {
-              assertThat(it).containsEntry("dpsAuthorisationId", dpsId.toString())
-              assertThat(it).containsEntry("nomisApplicationId", nomisId.toString())
-              assertThat(it).containsEntry("offenderNo", prisonerNumber)
-              assertThat(it).containsEntry("bookingId", "12345")
-            },
-            isNull(),
-          )
-        }
-
-        @Test
-        fun `will call back to DPS to get authorisation details`() {
-          dpsApi.verify(getRequestedFor(urlEqualTo("/sync/temporary-absence-authorisations/$dpsId")))
-        }
-
-        @Test
-        fun `will create the application in NOMIS`() {
-          nomisApi.verify(putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")))
-        }
-
-        @Test
-        fun `the created application will contain correct details`() {
-          nomisApi.verify(
-            putRequestedFor(anyUrl())
-              .withRequestBodyJsonPath("eventSubType", "R2")
-              .withRequestBodyJsonPath("fromDate", today.toLocalDate())
-              .withRequestBodyJsonPath("toDate", tomorrow.toLocalDate())
-              .withRequestBodyJsonPath("comment", "Some notes")
-              .withRequestBodyJsonPath("temporaryAbsenceType", "SR")
-              .withRequestBodyJsonPath("temporaryAbsenceSubType", "RDR")
-              .withRequestBodyJsonPath("transportType", "VAN"),
-          )
-        }
-
-        @Test
-        fun `will create a mapping between the NOMIS and DPS ids`() {
-          mappingApi.verify(
-            postRequestedFor(urlEqualTo("/mapping/temporary-absence/application"))
-              .withRequestBodyJsonPath("dpsMovementApplicationId", "$dpsId")
-              .withRequestBodyJsonPath("nomisMovementApplicationId", "$nomisId")
-              .withRequestBodyJsonPath("prisonerNumber", "A1234BC")
-              .withRequestBodyJsonPath("bookingId", "12345")
-              .withRequestBodyJsonPath("mappingType", "DPS_CREATED"),
-          )
-        }
-      }
-
-      @Nested
-      @DisplayName("when mapping service fails once")
-      inner class MappingFailure {
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, status = NOT_FOUND)
-          dpsApi.stubGetTapAuthorisation(dpsId)
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-          mappingApi.stubCreateTemporaryAbsenceApplicationMappingFailureFollowedBySuccess()
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-        }
-
-        @Test
-        fun `will send telemetry for initial mapping failure`() {
-          await untilAsserted {
-            verify(telemetryClient).trackEvent(
-              eq("temporary-absence-application-mapping-create-error"),
-              check {
-                assertThat(it).containsEntry("error", "500 Internal Server Error from POST http://localhost:8084/mapping/temporary-absence/application")
-              },
-              isNull(),
-            )
-          }
-        }
-
-        @Test
-        fun `will send telemetry for application create`() {
-          await untilAsserted {
-            verify(telemetryClient).trackEvent(
-              eq("temporary-absence-application-create-success"),
-              any(),
-              isNull(),
-            )
-          }
-        }
-
-        @Test
-        fun `will create the application in NOMIS once`() {
-          await untilAsserted {
-            nomisApi.verify(1, putRequestedFor(urlEqualTo("/movements/A1234BC/temporary-absences/application")))
-          }
-        }
-      }
-
-      @Nested
-      @DisplayName("when mapping service detects a duplicate mapping")
-      inner class DuplicateMappingFailure {
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, NOT_FOUND)
-          dpsApi.stubGetTapAuthorisation(dpsId)
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-          mappingApi.stubCreateTemporaryAbsenceApplicationMappingConflict(
-            error = DuplicateMappingErrorResponse(
-              moreInfo = DuplicateErrorContentObject(
-                existing = TemporaryAbsenceApplicationSyncMappingDto(
-                  prisonerNumber = "A1234BC",
-                  bookingId = 12345L,
-                  nomisMovementApplicationId = nomisId,
-                  dpsMovementApplicationId = dpsId,
-                  mappingType = TemporaryAbsenceApplicationSyncMappingDto.MappingType.NOMIS_CREATED,
-                ),
-                duplicate = TemporaryAbsenceApplicationSyncMappingDto(
-                  prisonerNumber = "A1234BC",
-                  bookingId = 12345L,
-                  nomisMovementApplicationId = nomisId + 1,
-                  dpsMovementApplicationId = dpsId,
-                  mappingType = TemporaryAbsenceApplicationSyncMappingDto.MappingType.NOMIS_CREATED,
-                ),
-              ),
-              errorCode = 1409,
-              status = DuplicateMappingErrorResponse.Status._409_CONFLICT,
-              userMessage = "Duplicate mapping",
-            ),
-          )
-
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-        }
-
-        @Test
-        fun `will send telemetry for duplicate`() {
-          await untilAsserted {
-            verify(telemetryClient).trackEvent(
-              eq("to-nomis-synch-temporary-absence-application-duplicate"),
-              any(),
-              isNull(),
-            )
-          }
-        }
-
-        @Test
-        fun `will create the application in NOMIS once`() {
-          await untilAsserted {
-            verify(telemetryClient).trackEvent(
-              eq("to-nomis-synch-temporary-absence-application-duplicate"),
-              any(),
-              isNull(),
-            )
-            nomisApi.verify(1, putRequestedFor(urlEqualTo("/movements/A1234BC/temporary-absences/application")))
-          }
-        }
-      }
-    }
-
-    @Nested
-    @DisplayName("when we receive a relocated event for a new authorisation")
-    inner class IgnoreRelocatedEventType {
-
-      @BeforeEach
-      fun setUp() {
-        mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, status = NOT_FOUND)
-
-        publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS", "person.temporary-absence-authorisation.relocated")
-        waitForAnyProcessingToComplete()
-      }
-
-      @Test
-      fun `will check if the application mapping exists`() {
-        mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/application/dps-id/$dpsId")))
-      }
-
-      @Test
-      fun `will send telemetry event showing the create was ignored`() {
-        verify(telemetryClient).trackEvent(
-          eq("temporary-absence-application-create-ignored"),
-          check {
-            assertThat(it).containsEntry("dpsAuthorisationId", dpsId.toString())
-            assertThat(it).containsEntry("offenderNo", prisonerNumber)
-            assertThat(it).containsEntry("reason", "This event is applied to updates only")
-          },
-          isNull(),
-        )
-      }
-
-      @Test
-      fun `will NOT create the application in NOMIS once`() {
-        await untilAsserted {
-          nomisApi.verify(0, putRequestedFor(urlEqualTo("/movements/A1234BC/temporary-absences/application")))
-        }
-      }
-    }
-  }
-
-  @Nested
-  @DisplayName("person.temporary-absence-authorisation.approved (updated)")
-  inner class TemporaryAbsenceApplicationUpdated {
-    private val prisonerNumber = "A1234BC"
-    private val dpsId = UUID.randomUUID()
-    private val nomisId = 56789L
-
-    @Nested
-    @DisplayName("when NOMIS is the origin of an authorisation approval")
-    inner class WhenNomisUpdated {
-
-      @BeforeEach
-      fun setUp() {
-        publishAuthorisationDomainEvent(dpsAuthorisationId = dpsId, prisonerNumber = prisonerNumber, source = "NOMIS")
-        waitForAnyProcessingToComplete()
-      }
-
-      @Test
-      fun `will send telemetry event showing the ignore`() {
-        verify(telemetryClient).trackEvent(
-          eq("temporary-absence-application-create-ignored"),
-          any(),
-          isNull(),
-        )
-      }
-
-      @Test
-      fun `will NOT create the application in NOMIS`() {
-        nomisApi.verify(0, putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")))
-      }
-
-      @Test
-      fun `will NOT create any mappings`() {
-        mappingApi.verify(0, postRequestedFor(urlEqualTo("/mapping/temporary-absence/application")))
-      }
-    }
-
-    @Nested
-    @DisplayName("when DPS is the origin of an authorisation approval")
-    inner class WhenDpsCreated {
-      @Nested
-      @DisplayName("when all goes ok")
-      inner class HappyPath {
-        private val startTime = today
-        private val endTime = today.plusHours(1)
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
-          dpsApi.stubGetTapAuthorisation(dpsId, response = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 0, startTime = startTime, endTime = endTime))
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-          waitForAnyProcessingToComplete()
-        }
-
-        @Test
-        fun `will send telemetry event showing the update`() {
-          verify(telemetryClient).trackEvent(
-            eq("temporary-absence-application-update-success"),
-            any(),
-            isNull(),
-          )
-        }
-
-        @Test
-        fun `will check if the application mapping exists`() {
-          mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/application/dps-id/$dpsId")))
-        }
-
-        @Test
-        fun `telemetry will contain key facts about the application updated`() {
-          verify(telemetryClient).trackEvent(
-            eq("temporary-absence-application-update-success"),
-            check {
-              assertThat(it).containsEntry("dpsAuthorisationId", dpsId.toString())
-              assertThat(it).containsEntry("nomisApplicationId", nomisId.toString())
-              assertThat(it).containsEntry("offenderNo", prisonerNumber)
-              assertThat(it).containsEntry("bookingId", "12345")
-            },
-            isNull(),
-          )
-        }
-
-        @Test
-        fun `will call back to DPS to get authorisation details`() {
-          dpsApi.verify(getRequestedFor(urlEqualTo("/sync/temporary-absence-authorisations/$dpsId")))
-        }
-
-        @Test
-        fun `will update the application in NOMIS`() {
-          nomisApi.verify(
-            putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application"))
-              .withRequestBodyJsonPath("escortCode", "U"),
-          )
-        }
-
-        @Test
-        fun `the updated application will contain correct details`() {
-          nomisApi.verify(
-            putRequestedFor(anyUrl())
-              .withRequestBodyJsonPath("eventSubType", "R2")
-              .withRequestBodyJsonPath("fromDate", startTime.toLocalDate())
-              .withRequestBodyJsonPath("toDate", endTime.toLocalDate())
-              .withRequestBodyJsonPath("releaseTime", equalToDateTime(startTime.toLocalDate().atStartOfDay()))
-              .withRequestBodyJsonPath("returnTime", equalToDateTime(endTime.plusDays(1).toLocalDate().atStartOfDay().minusMinutes(1)))
-              .withRequestBodyJsonPath("comment", "Some notes")
-              .withRequestBodyJsonPath("temporaryAbsenceType", "SR")
-              .withRequestBodyJsonPath("temporaryAbsenceSubType", "RDR")
-              .withRequestBodyJsonPath("transportType", "VAN")
-              // Address is only updated when the application update is triggered by synchronising the DPS occurrence
-              .withRequestBodyJsonPath("toAddress", absent()),
-          )
-        }
-      }
-
-      @Nested
-      @DisplayName("when all goes ok for a single schedule")
-      inner class HappyPathWithSingleSchedule {
-        private val startTime = today
-        private val endTime = today.plusHours(1)
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
-          dpsApi.stubGetTapAuthorisation(id = dpsId, response = dpsApi.tapAuthorisation(id = dpsId, repeat = false, occurrenceCount = 1, startTime = startTime, endTime = endTime))
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-          waitForAnyProcessingToComplete()
-        }
-
-        @Test
-        fun `the updated application's start and end times to match occurrences`() {
-          nomisApi.verify(
-            putRequestedFor(anyUrl())
-              .withRequestBodyJsonPath("fromDate", "${startTime.toLocalDate()}")
-              .withRequestBodyJsonPath("toDate", "${endTime.toLocalDate()}")
-              .withRequestBodyJsonPath("releaseTime", equalToDateTime(startTime))
-              .withRequestBodyJsonPath("returnTime", equalToDateTime(endTime)),
-          )
-        }
-      }
-
-      @Nested
-      @DisplayName("when all goes ok for multiple schedules")
-      inner class HappyPathWithMultipleSchedules {
-        private val startTime = today
-        private val endTime = tomorrow.plusDays(1)
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
-          dpsApi.stubGetTapAuthorisation(id = dpsId, response = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 2, startTime = startTime, endTime = endTime))
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-          waitForAnyProcessingToComplete()
-        }
-
-        @Test
-        fun `the updated application's start and end times to match occurrences`() {
-          nomisApi.verify(
-            putRequestedFor(anyUrl())
-              .withRequestBodyJsonPath("fromDate", "${startTime.toLocalDate()}")
-              .withRequestBodyJsonPath("toDate", "${endTime.toLocalDate()}")
-              .withRequestBodyJsonPath("releaseTime", equalToDateTime(startTime.toLocalDate().atStartOfDay()))
-              .withRequestBodyJsonPath("returnTime", equalToDateTime(endTime.plusDays(1).toLocalDate().atStartOfDay().minusMinutes(1))),
-          )
-        }
-
-        @Test
-        fun `all occurrence addresses are sent to NOMIS`() {
-          nomisApi.verify(
-            putRequestedFor(anyUrl())
-              .withRequestBodyJsonPath("toAddresses.length()", 2)
-              .withRequestBodyJsonPath("toAddresses[0].addressText", "some address 1")
-              .withRequestBodyJsonPath("toAddresses[0].name", "some description 1")
-              .withRequestBodyJsonPath("toAddresses[0].postalCode", "some postcode 1")
-              .withRequestBodyJsonPath("toAddresses[1].addressText", "some address 2")
-              .withRequestBodyJsonPath("toAddresses[1].name", "some description 2")
-              .withRequestBodyJsonPath("toAddresses[1].postalCode", "some postcode 2"),
-          )
-        }
-      }
-
-      @Nested
-      @DisplayName("when there are multiple schedules with the same NOMIS address")
-      inner class MultipleSchedulesWithSameNomisAddress {
-        private val startTime = today
-        private val endTime = tomorrow.plusDays(1)
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
-          val authorisation = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 3, startTime = startTime, endTime = endTime)
-          dpsApi.stubGetTapAuthorisation(id = dpsId, response = authorisation)
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-          // Create a stub for the first schedule mapping only (which is same as third schedule)
-          with(authorisation.occurrences[0]) {
-            mappingApi.stubGetTemporaryAbsenceScheduledMovementMapping(
-              dpsId = id,
-              mapping = temporaryAbsenceScheduledMovementMapping().copy(
-                prisonerNumber = prisonerNumber,
-                dpsOccurrenceId = id,
-                nomisAddressId = 1,
-                dpsDescription = "some description 1",
-                dpsAddressText = "some address 1",
-                dpsPostcode = "some postcode 1",
-              ),
-            )
-          }
-
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-          waitForAnyProcessingToComplete()
-        }
-
-        @Test
-        fun `we get the occurrence mappings for the 2 unique addresses`() {
-          mappingApi.verify(
-            2,
-            getRequestedFor(urlMatching("/mapping/temporary-absence/scheduled-movement/dps-id/.*")),
-          )
-        }
-
-        @Test
-        fun `the updated application's locations contain the NOMIS address IDs from the occurrence mappings`() {
-          nomisApi.verify(
-            putRequestedFor(anyUrl())
-              .withRequestBodyJsonPath("toAddresses.length()", 2)
-              // we found the existing NOMIS address
-              .withRequestBodyJsonPath("toAddresses[0].id", 1)
-              .withRequestBodyJsonPath("toAddresses[0].addressText", absent())
-              // there is no NOMIS address so NOMIS will create a new one
-              .withRequestBodyJsonPath("toAddresses[1].id", absent())
-              .withRequestBodyJsonPath("toAddresses[1].name", "some description 2")
-              .withRequestBodyJsonPath("toAddresses[1].addressText", "some address 2")
-              .withRequestBodyJsonPath("toAddresses[1].postalCode", "some postcode 2"),
-          )
-        }
-      }
-
-      @Nested
-      @DisplayName("when all goes ok for zero schedules")
-      inner class HappyPathWithZeroSchedules {
-        private val startTime = today
-        private val endTime = tomorrow.plusDays(1)
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
-          dpsApi.stubGetTapAuthorisation(id = dpsId, response = dpsApi.tapAuthorisation(id = dpsId, repeat = false, occurrenceCount = 0, startTime = startTime, endTime = endTime, statusCode = "EXPIRED"))
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-          waitForAnyProcessingToComplete()
-        }
-
-        @Test
-        fun `the updated application's start and end times match DPS`() {
-          nomisApi.verify(
-            putRequestedFor(anyUrl())
-              .withRequestBodyJsonPath("applicationStatus", "PEN")
-              .withRequestBodyJsonPath("fromDate", "${startTime.toLocalDate()}")
-              .withRequestBodyJsonPath("toDate", "${endTime.toLocalDate()}")
-              .withRequestBodyJsonPath("releaseTime", equalToDateTime(startTime.toLocalDate().atStartOfDay()))
-              .withRequestBodyJsonPath("returnTime", equalToDateTime(endTime.plusDays(1).toLocalDate().atStartOfDay().minusMinutes(1))),
-          )
-        }
-      }
-
-      @Nested
-      @DisplayName("when we receive an update request for authorisation relocated")
-      inner class UpdateForRelocatedEventType {
-        private val startTime = today
-        private val endTime = today.plusHours(1)
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
-          dpsApi.stubGetTapAuthorisation(dpsId, response = dpsApi.tapAuthorisation(id = dpsId, occurrenceCount = 0, startTime = startTime, endTime = endTime))
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, upsertTemporaryAbsenceApplicationResponse())
-
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS", "person.temporary-absence-authorisation.relocated")
-          waitForAnyProcessingToComplete()
-        }
-
-        @Test
-        fun `will send telemetry event showing the update`() {
-          verify(telemetryClient).trackEvent(
-            eq("temporary-absence-application-update-success"),
-            any(),
-            isNull(),
-          )
-        }
-
-        @Test
-        fun `will update the application in NOMIS`() {
-          nomisApi.verify(
-            putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")),
-          )
-        }
-      }
-
-      @Nested
-      inner class WhenNomisUpdateFails {
-
-        @BeforeEach
-        fun setUp() {
-          mappingApi.stubGetTemporaryAbsenceApplicationMapping(dpsId = dpsId, nomisMovementApplicationId = nomisId)
-          dpsApi.stubGetTapAuthorisation(dpsId)
-          nomisApi.stubUpsertTemporaryAbsenceApplication(prisonerNumber, HttpStatus.INTERNAL_SERVER_ERROR)
-          mappingApi.stubCreateTemporaryAbsenceApplicationMapping()
-
-          publishAuthorisationDomainEvent(dpsId, prisonerNumber, "DPS")
-          waitForAnyProcessingToComplete("temporary-absence-application-update-error")
-        }
-
-        @Test
-        fun `will check if the application mapping exists`() {
-          mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/application/dps-id/$dpsId")))
-        }
-
-        @Test
-        fun `telemetry will contain key facts about the application`() {
-          verify(telemetryClient).trackEvent(
-            eq("temporary-absence-application-update-error"),
-            check {
-              assertThat(it).containsEntry("dpsAuthorisationId", dpsId.toString())
-              assertThat(it).containsEntry("offenderNo", prisonerNumber)
-              assertThat(it).containsEntry("error", "500 Internal Server Error from PUT http://localhost:8082/movements/A1234BC/temporary-absences/application")
-            },
-            isNull(),
-          )
-        }
-
-        @Test
-        fun `will call back to DPS to get authorisation details`() {
-          dpsApi.verify(getRequestedFor(urlEqualTo("/sync/temporary-absence-authorisations/$dpsId")))
-        }
-
-        @Test
-        fun `will attempt to update the application in NOMIS`() {
-          nomisApi.verify(putRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application")))
-        }
-
-        @Test
-        fun `will put the message on the DLQ`() {
-          assertThat(movementsDlqClient!!.countAllMessagesOnQueue(movementsDlqUrl!!).get()).isEqualTo(1)
-        }
-      }
-    }
-  }
-
-  @Nested
   @DisplayName("person.temporary-absence.scheduled (created)")
-  inner class TemporaryAbsenceScheduledMovementCreated {
+  inner class TapOccurrenceMovementCreated {
     private val prisonerNumber = "A1234BC"
     private val dpsOccurrenceId = UUID.randomUUID()
     private val dpsAuthorisationId = UUID.randomUUID()
@@ -1021,7 +401,7 @@ class ExternalMovementsToNomisIntTest : SqsIntegrationTestBase() {
 
   @Nested
   @DisplayName("person.temporary-absence.scheduled (updated)")
-  inner class TemporaryAbsenceScheduledMovementUpdated {
+  inner class TapOccurrenceMovementUpdated {
     private val prisonerNumber = "A1234BC"
     private val dpsOccurrenceId = UUID.randomUUID()
     private val dpsAuthorisationId = UUID.randomUUID()
@@ -1251,7 +631,7 @@ class ExternalMovementsToNomisIntTest : SqsIntegrationTestBase() {
 
   @Nested
   @DisplayName("person.temporary-absence.unscheduled")
-  inner class TemporaryAbsenceScheduledMovementDeleted {
+  inner class TapOccurrenceMovementDeleted {
     private val prisonerNumber = "A1234BC"
     private val dpsOccurrenceId = UUID.randomUUID()
     private val nomisEventId = 54321L
@@ -1347,12 +727,6 @@ class ExternalMovementsToNomisIntTest : SqsIntegrationTestBase() {
         },
         isNull(),
       )
-    }
-  }
-
-  private fun publishAuthorisationDomainEvent(dpsAuthorisationId: UUID, prisonerNumber: String, source: String = "DPS", eventType: String = "person.temporary-absence-authorisation.approved") {
-    with(eventType) {
-      publishDomainEvent(eventType = this, payload = messagePayload(eventType = this, id = dpsAuthorisationId, prisonerNumber = prisonerNumber, source = source))
     }
   }
 


### PR DESCRIPTION
Next refactor - rename/move some classes and split integration tests into a file per entity. No actual code changes have been made, just renaming  and moving things.