### PR TITLE
SDIT-2832 Refactor - switch to new NOMIS API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapAllPrisonersReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapAllPrisonersReconciliationService.kt
@@ -20,13 +20,14 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.Person
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.PersonTapDetail
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.model.ReconciliationMovement
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTapMovementId
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTapsIdsResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceId
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceIdsResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceSummaryResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.PrisonerId
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.TapSummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.NomisApiService
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.awaitBoth
-import java.util.UUID
+import java.util.*
 
 @Service
 class TemporaryAbsencesAllPrisonersReconciliationService(
@@ -112,7 +113,7 @@ class TemporaryAbsencesAllPrisonersReconciliationService(
 
   suspend fun checkPrisonerTapsMatch(offenderNo: String, suppressTelemetry: Boolean = false): List<MismatchPrisonerTapsSummary> {
     val (nomisTaps, dpsTaps) = withContext(Dispatchers.Unconfined) {
-      async { nomisApiService.getTemporaryAbsenceSummary(offenderNo) } to
+      async { nomisApiService.getTapCounts(offenderNo) } to
         async { dpsApiService.getTapReconciliation(offenderNo) }
     }.awaitBoth()
     return checkTapsMatch(
@@ -123,13 +124,13 @@ class TemporaryAbsencesAllPrisonersReconciliationService(
     )
   }
 
-  private suspend fun checkTapsMatch(offenderNo: String, dpsTaps: PersonTapCounts, nomisTaps: OffenderTemporaryAbsenceSummaryResponse, suppressTelemetry: Boolean): List<MismatchPrisonerTapsSummary> {
+  private suspend fun checkTapsMatch(offenderNo: String, dpsTaps: PersonTapCounts, nomisTaps: TapSummary, suppressTelemetry: Boolean): List<MismatchPrisonerTapsSummary> {
     val mismatches = mutableListOf<MismatchPrisonerTapsSummary>()
     if (dpsTaps.authorisations.count != nomisTaps.applications.count.toInt()) {
       mismatches += MismatchPrisonerTapsSummary(offenderNo, MismatchPrisonerTapsSummary.Types.AUTHORISATIONS, dpsTaps.authorisations.count, nomisTaps.applications.count.toInt())
     }
-    if (dpsTaps.occurrences.count != nomisTaps.scheduledOutMovements.count.toInt()) {
-      mismatches += MismatchPrisonerTapsSummary(offenderNo, MismatchPrisonerTapsSummary.Types.OCCURRENCES, dpsTaps.occurrences.count, nomisTaps.scheduledOutMovements.count.toInt())
+    if (dpsTaps.occurrences.count != nomisTaps.scheduledOuts.count.toInt()) {
+      mismatches += MismatchPrisonerTapsSummary(offenderNo, MismatchPrisonerTapsSummary.Types.OCCURRENCES, dpsTaps.occurrences.count, nomisTaps.scheduledOuts.count.toInt())
     }
     if (dpsTaps.movements.scheduled.outCount != nomisTaps.movements.scheduled.outCount.toInt()) {
       mismatches += MismatchPrisonerTapsSummary(offenderNo, MismatchPrisonerTapsSummary.Types.SCHEDULED_OUT, dpsTaps.movements.scheduled.outCount, nomisTaps.movements.scheduled.outCount.toInt())
@@ -147,7 +148,7 @@ class TemporaryAbsencesAllPrisonersReconciliationService(
     if (mismatches.isEmpty()) return emptyList()
 
     withContext(Dispatchers.Unconfined) {
-      val nomisIds = async { nomisApiService.getTemporaryAbsenceIds(offenderNo) }
+      val nomisIds = async { nomisApiService.getTapIds(offenderNo) }
       val dpsIds = async { dpsApiService.getTapReconciliationDetail(offenderNo) }
       val mappings = async { mappingService.getTapMappingIds(offenderNo) }
 
@@ -177,7 +178,7 @@ class TemporaryAbsencesAllPrisonersReconciliationService(
   // Checks each NOMIS ID for a mapping to a real DPS ID, and vice versa. Any not found are returned
   private fun findMismatchedIds(
     type: MismatchPrisonerTapsSummary.Types,
-    nomisIds: OffenderTemporaryAbsenceIdsResponse,
+    nomisIds: OffenderTapsIdsResponse,
     dpsIds: PersonTapDetail,
     mappings: TemporaryAbsencesPrisonerMappingIdsDto,
   ): MismatchedIds = when (type) {
@@ -218,7 +219,7 @@ class TemporaryAbsencesAllPrisonersReconciliationService(
     }
   }.let { MismatchedIds(nomisIds = "${it.first}", dpsIds = "${it.second}") }
 
-  private fun List<OffenderTemporaryAbsenceId>.format() = joinToString(prefix = "[", postfix = "]") { "${it.bookingId}_${it.sequence}" }
+  private fun List<OffenderTapMovementId>.format() = joinToString(prefix = "[", postfix = "]") { "${it.bookingId}_${it.sequence}" }
 
   // This checks each element of `sources` exists in `targets` after transformation by `findTarget`
   private fun <SOURCE, TARGET> findMissing(
@@ -259,7 +260,7 @@ class TemporaryAbsencesAllPrisonersReconciliationService(
   }
 
   private fun TemporaryAbsencesPrisonerMappingIdsDto.unexpectedNomisMovements(
-    nomisMovementIds: List<OffenderTemporaryAbsenceId>,
+    nomisMovementIds: List<OffenderTapMovementId>,
     dpsMovementIds: List<UUID>,
   ) = findMissing(nomisMovementIds, dpsMovementIds) { nomisId ->
     this.movements.find { nomisId.bookingId == it.nomisBookingId && nomisId.sequence == it.nomisMovementSeq }?.dpsMovementId
@@ -267,7 +268,7 @@ class TemporaryAbsencesAllPrisonersReconciliationService(
 
   private fun TemporaryAbsencesPrisonerMappingIdsDto.unexpectedDpsMovements(
     dpsMovementIds: List<UUID>,
-    nomisMovementIds: List<OffenderTemporaryAbsenceId>,
+    nomisMovementIds: List<OffenderTapMovementId>,
   ) = findMissing(dpsMovementIds, nomisMovementIds) { dpsId ->
     movements.find { dpsId == it.dpsMovementId }?.let { OffenderTemporaryAbsenceId(it.nomisBookingId, it.nomisMovementSeq) }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiService.kt
@@ -10,16 +10,18 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyOrLog
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyOrNullForNotFound
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyWithRetry
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.api.MovementsResourceApi
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.api.OffenderTapsResourceApi
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.api.TapApplicationResourceApi
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.api.TapMovementResourceApi
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.api.TapScheduleResourceApi
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.BookingTemporaryAbsences
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTemporaryAbsenceRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTemporaryAbsenceResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTemporaryAbsenceReturnRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTemporaryAbsenceReturnResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceIdsResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceSummaryResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTapMovementIn
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTapMovementInResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTapMovementOut
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTapMovementOutResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTapsIdsResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsencesResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.TapSummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpsertTapApplication
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpsertTapApplicationResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpsertTapScheduleOut
@@ -38,6 +40,8 @@ class TapNomisApiService(
   private val movementsApi = MovementsResourceApi(webClient)
   private val applicationApi = TapApplicationResourceApi(webClient)
   private val scheduleApi = TapScheduleResourceApi(webClient)
+  private val movementApi = TapMovementResourceApi(webClient)
+  private val offenderApi = OffenderTapsResourceApi(webClient)
 
   suspend fun upsertTapApplication(offenderNo: String, request: UpsertTapApplication): UpsertTapApplicationResponse = applicationApi.prepare(applicationApi.upsertTapApplicationRequestConfig(offenderNo, request))
     .retrieve()
@@ -47,19 +51,23 @@ class TapNomisApiService(
     .retrieve()
     .awaitBodyOrLogAndRethrowBadRequest()
 
-  suspend fun createTemporaryAbsence(offenderNo: String, request: CreateTemporaryAbsenceRequest): CreateTemporaryAbsenceResponse = movementsApi.prepare(movementsApi.createTemporaryAbsenceRequestConfig(offenderNo, request))
+  suspend fun deleteTapScheduleOut(offenderNo: String, eventId: Long) = scheduleApi.prepare(scheduleApi.deleteTapScheduleOutRequestConfig(offenderNo, eventId))
+    .retrieve()
+    .awaitBodilessEntityOrLogAndRethrowBadRequest()
+
+  suspend fun createTapMovementOut(offenderNo: String, request: CreateTapMovementOut): CreateTapMovementOutResponse = movementApi.prepare(movementApi.createTapMovementOutRequestConfig(offenderNo, request))
     .retrieve()
     .awaitBodyOrLogAndRethrowBadRequest()
 
-  suspend fun createTemporaryAbsenceReturn(offenderNo: String, request: CreateTemporaryAbsenceReturnRequest): CreateTemporaryAbsenceReturnResponse = movementsApi.prepare(movementsApi.createTemporaryAbsenceReturnRequestConfig(offenderNo, request))
+  suspend fun createTapMovementIn(offenderNo: String, request: CreateTapMovementIn): CreateTapMovementInResponse = movementApi.prepare(movementApi.createTapMovementInRequestConfig(offenderNo, request))
     .retrieve()
     .awaitBodyOrLogAndRethrowBadRequest()
 
-  suspend fun getTemporaryAbsenceSummary(offenderNo: String): OffenderTemporaryAbsenceSummaryResponse = movementsApi.prepare(movementsApi.getTemporaryAbsencesAndMovementCountsRequestConfig(offenderNo))
+  suspend fun getTapCounts(offenderNo: String): TapSummary = offenderApi.prepare(offenderApi.getTapCountsRequestConfig(offenderNo))
     .retrieve()
     .awaitBodyWithRetry(backoffSpec)
 
-  suspend fun getTemporaryAbsenceIds(offenderNo: String): OffenderTemporaryAbsenceIdsResponse = movementsApi.getTemporaryAbsencesAndMovementIds(offenderNo)
+  suspend fun getTapIds(offenderNo: String): OffenderTapsIdsResponse = offenderApi.getTapsIds(offenderNo)
     .awaitSingle()
 
   suspend fun getBookingTemporaryAbsences(bookingId: Long): BookingTemporaryAbsences? = movementsApi.prepare(movementsApi.getTemporaryAbsencesAndMovementsForBookingRequestConfig(bookingId))
@@ -69,8 +77,4 @@ class TapNomisApiService(
   suspend fun getTemporaryAbsencesOrNull(offenderNo: String): OffenderTemporaryAbsencesResponse? = movementsApi.prepare(movementsApi.getTemporaryAbsencesAndMovementsRequestConfig(offenderNo))
     .retrieve()
     .awaitBodyOrNullForNotFound()
-
-  suspend fun deleteTapScheduleOut(offenderNo: String, eventId: Long) = scheduleApi.prepare(scheduleApi.deleteTapScheduleOutRequestConfig(offenderNo, eventId))
-    .retrieve()
-    .awaitBodilessEntityOrLogAndRethrowBadRequest()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapAllPrisonersReconciliationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapAllPrisonersReconciliationIntTest.kt
@@ -35,13 +35,13 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.Ex
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.ScheduledMovementMappingIdsDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.TemporaryAbsenceApplicationMappingIdsDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Applications
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Movements
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ApplicationSummary
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.MovementSummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.MovementsByDirection
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceId
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceIdsResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceSummaryResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ScheduledOut
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTapMovementId
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTapsIdsResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ScheduledOutSummary
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.TapSummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.NomisApiExtension
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.generateOffenderNo
 import java.util.*
@@ -68,11 +68,11 @@ class TapAllPrisonersReconciliationIntTest(
       )
 
       // both same
-      nomisApi.stubGetTemporaryAbsencePrisonerSummary(offenderNo = "A0001TZ")
+      nomisApi.stubGetTapCounts(offenderNo = "A0001TZ")
       dpsApi.stubGetTapReconciliation(personIdentifier = "A0001TZ")
 
       // one count different
-      nomisApi.stubGetTemporaryAbsencePrisonerSummary(offenderNo = "A0002TZ")
+      nomisApi.stubGetTapCounts(offenderNo = "A0002TZ")
       dpsApi.stubGetTapReconciliation(
         personIdentifier = "A0002TZ",
         response = PersonTapCounts(
@@ -85,7 +85,7 @@ class TapAllPrisonersReconciliationIntTest(
       stubDifferenceIdsEmpty("A0002TZ")
 
       // all counts different
-      nomisApi.stubGetTemporaryAbsencePrisonerSummary(offenderNo = "A0003TZ")
+      nomisApi.stubGetTapCounts(offenderNo = "A0003TZ")
       dpsApi.stubGetTapReconciliation(
         personIdentifier = "A0003TZ",
         response = PersonTapCounts(
@@ -241,25 +241,25 @@ class TapAllPrisonersReconciliationIntTest(
 
       @BeforeEach
       fun `create stubs with unexpected NOMIS application, schedule and movements OUT and IN`() = runTest {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(
+        nomisApi.stubGetTapCounts(
           offenderNo = "A0001TZ",
           response = emptyTemporaryAbsenceSummaryResponse().copy(
-            applications = Applications(1),
-            scheduledOutMovements = ScheduledOut(1),
-            movements = Movements(
+            applications = ApplicationSummary(1),
+            scheduledOuts = ScheduledOutSummary(1),
+            movements = MovementSummary(
               count = 1,
               scheduled = MovementsByDirection(outCount = 1, inCount = 1),
               unscheduled = MovementsByDirection(outCount = 0, inCount = 0),
             ),
           ),
         )
-        nomisApi.stubGetTemporaryAbsencePrisonerSummaryIds(
+        nomisApi.stubGetTapIds(
           offenderNo = "A0001TZ",
-          response = emptyTemporaryAbsenceSummaryIdsResponse().copy(
+          response = emptyTapsIdsResponse().copy(
             applicationIds = listOf(unexpectedApplicationId),
             scheduleOutIds = listOf(unexpectedScheduleId),
-            scheduledMovementOutIds = listOf(OffenderTemporaryAbsenceId(12345L, unexpectedMovementOutSeq)),
-            scheduledMovementInIds = listOf(OffenderTemporaryAbsenceId(12345L, unexpectedMovementInSeq)),
+            scheduledMovementOutIds = listOf(OffenderTapMovementId(12345L, unexpectedMovementOutSeq)),
+            scheduledMovementInIds = listOf(OffenderTapMovementId(12345L, unexpectedMovementInSeq)),
           ),
         )
         mappingApi.stubGetTemporaryAbsenceMappingIds(
@@ -361,25 +361,25 @@ class TapAllPrisonersReconciliationIntTest(
 
       @BeforeEach
       fun `create stubs with unexpected NOMIS application, schedule and movements, BUT no mappings`() = runTest {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(
+        nomisApi.stubGetTapCounts(
           offenderNo = "A0001TZ",
           response = emptyTemporaryAbsenceSummaryResponse().copy(
-            applications = Applications(1),
-            scheduledOutMovements = ScheduledOut(1),
-            movements = Movements(
+            applications = ApplicationSummary(1),
+            scheduledOuts = ScheduledOutSummary(1),
+            movements = MovementSummary(
               count = 1,
               scheduled = MovementsByDirection(outCount = 1, inCount = 1),
               unscheduled = MovementsByDirection(outCount = 0, inCount = 0),
             ),
           ),
         )
-        nomisApi.stubGetTemporaryAbsencePrisonerSummaryIds(
+        nomisApi.stubGetTapIds(
           offenderNo = "A0001TZ",
-          response = emptyTemporaryAbsenceSummaryIdsResponse().copy(
+          response = emptyTapsIdsResponse().copy(
             applicationIds = listOf(unexpectedApplicationId),
             scheduleOutIds = listOf(unexpectedScheduleId),
-            scheduledMovementOutIds = listOf(OffenderTemporaryAbsenceId(12345L, unexpectedMovementOutSeq)),
-            scheduledMovementInIds = listOf(OffenderTemporaryAbsenceId(12345L, unexpectedMovementInSeq)),
+            scheduledMovementOutIds = listOf(OffenderTapMovementId(12345L, unexpectedMovementOutSeq)),
+            scheduledMovementInIds = listOf(OffenderTapMovementId(12345L, unexpectedMovementInSeq)),
           ),
         )
 
@@ -598,21 +598,21 @@ class TapAllPrisonersReconciliationIntTest(
 
       @BeforeEach
       fun `create stubs for unexpected NOMIS unscheduled movements`() = runTest {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(
+        nomisApi.stubGetTapCounts(
           offenderNo = "A0001TZ",
           response = emptyTemporaryAbsenceSummaryResponse().copy(
-            movements = Movements(
+            movements = MovementSummary(
               count = 2,
               scheduled = MovementsByDirection(0, 0),
               unscheduled = MovementsByDirection(outCount = 1, inCount = 1),
             ),
           ),
         )
-        nomisApi.stubGetTemporaryAbsencePrisonerSummaryIds(
+        nomisApi.stubGetTapIds(
           offenderNo = "A0001TZ",
-          response = emptyTemporaryAbsenceSummaryIdsResponse().copy(
-            unscheduledMovementOutIds = listOf(OffenderTemporaryAbsenceId(12345L, unexpectedMovementOutSeq)),
-            unscheduledMovementInIds = listOf(OffenderTemporaryAbsenceId(12345L, unexpectedMovementInSeq)),
+          response = emptyTapsIdsResponse().copy(
+            unscheduledMovementOutIds = listOf(OffenderTapMovementId(12345L, unexpectedMovementOutSeq)),
+            unscheduledMovementInIds = listOf(OffenderTapMovementId(12345L, unexpectedMovementInSeq)),
           ),
         )
         mappingApi.stubGetTemporaryAbsenceMappingIds(
@@ -750,22 +750,22 @@ class TapAllPrisonersReconciliationIntTest(
 
       @BeforeEach
       fun `create stubs for unexpected NOMIS unscheduled movements`() = runTest {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(
+        nomisApi.stubGetTapCounts(
           offenderNo = "A0001TZ",
           response = emptyTemporaryAbsenceSummaryResponse().copy(
-            movements = Movements(
+            movements = MovementSummary(
               count = 2,
               scheduled = MovementsByDirection(0, 0),
               unscheduled = MovementsByDirection(outCount = 2, inCount = 0),
             ),
           ),
         )
-        nomisApi.stubGetTemporaryAbsencePrisonerSummaryIds(
+        nomisApi.stubGetTapIds(
           offenderNo = "A0001TZ",
-          response = emptyTemporaryAbsenceSummaryIdsResponse().copy(
+          response = emptyTapsIdsResponse().copy(
             unscheduledMovementOutIds = listOf(
-              OffenderTemporaryAbsenceId(12345L, unexpectedMovementOutSeq1),
-              OffenderTemporaryAbsenceId(12345L, unexpectedMovementOutSeq2),
+              OffenderTapMovementId(12345L, unexpectedMovementOutSeq1),
+              OffenderTapMovementId(12345L, unexpectedMovementOutSeq2),
             ),
           ),
         )
@@ -869,15 +869,15 @@ class TapAllPrisonersReconciliationIntTest(
 
       @BeforeEach
       fun `create stubs for unexpected NOMIS unscheduled movements`() = runTest {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(
+        nomisApi.stubGetTapCounts(
           offenderNo = "A0001TZ",
           response = emptyTemporaryAbsenceSummaryResponse().copy(
-            applications = Applications(2),
+            applications = ApplicationSummary(2),
           ),
         )
-        nomisApi.stubGetTemporaryAbsencePrisonerSummaryIds(
+        nomisApi.stubGetTapIds(
           offenderNo = "A0001TZ",
-          response = emptyTemporaryAbsenceSummaryIdsResponse().copy(
+          response = emptyTapsIdsResponse().copy(
             applicationIds = listOf(expectedApplicationId, unexpectedApplicationId),
           ),
         )
@@ -933,15 +933,15 @@ class TapAllPrisonersReconciliationIntTest(
 
       @BeforeEach
       fun `create stubs for unexpected NOMIS unscheduled movements`() = runTest {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(
+        nomisApi.stubGetTapCounts(
           offenderNo = "A0001TZ",
           response = emptyTemporaryAbsenceSummaryResponse().copy(
-            applications = Applications(1),
+            applications = ApplicationSummary(1),
           ),
         )
-        nomisApi.stubGetTemporaryAbsencePrisonerSummaryIds(
+        nomisApi.stubGetTapIds(
           offenderNo = "A0001TZ",
-          response = emptyTemporaryAbsenceSummaryIdsResponse().copy(
+          response = emptyTapsIdsResponse().copy(
             applicationIds = listOf(expectedApplicationId),
           ),
         )
@@ -999,15 +999,15 @@ class TapAllPrisonersReconciliationIntTest(
 
       @BeforeEach
       fun `create stubs for an unexpected OUT and IN schedule in NOMIS`() = runTest {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(
+        nomisApi.stubGetTapCounts(
           offenderNo = "A0001TZ",
           response = emptyTemporaryAbsenceSummaryResponse().copy(
-            scheduledOutMovements = ScheduledOut(1),
+            scheduledOuts = ScheduledOutSummary(1),
           ),
         )
-        nomisApi.stubGetTemporaryAbsencePrisonerSummaryIds(
+        nomisApi.stubGetTapIds(
           offenderNo = "A0001TZ",
-          response = emptyTemporaryAbsenceSummaryIdsResponse().copy(
+          response = emptyTapsIdsResponse().copy(
             scheduleOutIds = listOf(nomisScheduleOutId),
             scheduleInIds = listOf(nomisScheduleInId),
           ),
@@ -1048,7 +1048,7 @@ class TapAllPrisonersReconciliationIntTest(
     inner class RunReport {
       @Test
       fun `no differences found`() {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(offenderNo = "A0001TZ")
+        nomisApi.stubGetTapCounts(offenderNo = "A0001TZ")
         dpsApi.stubGetTapReconciliation(personIdentifier = "A0001TZ")
 
         webTestClient.getAllTapsPrisonerReconOk()
@@ -1059,7 +1059,7 @@ class TapAllPrisonersReconciliationIntTest(
 
       @Test
       fun `one different count`() {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(offenderNo = "A0001TZ")
+        nomisApi.stubGetTapCounts(offenderNo = "A0001TZ")
         dpsApi.stubGetTapReconciliation(
           personIdentifier = "A0001TZ",
           response = PersonTapCounts(
@@ -1083,7 +1083,7 @@ class TapAllPrisonersReconciliationIntTest(
 
       @Test
       fun `one different count should suppress telemetry`() {
-        nomisApi.stubGetTemporaryAbsencePrisonerSummary(offenderNo = "A0001TZ")
+        nomisApi.stubGetTapCounts(offenderNo = "A0001TZ")
         dpsApi.stubGetTapReconciliation(
           personIdentifier = "A0001TZ",
           response = PersonTapCounts(
@@ -1151,7 +1151,7 @@ class TapAllPrisonersReconciliationIntTest(
   }
 
   private fun stubEverythingEmpty(offenderNo: String = "A0001TZ") {
-    nomisApi.stubGetTemporaryAbsencePrisonerSummary(
+    nomisApi.stubGetTapCounts(
       offenderNo = offenderNo,
       response = emptyTemporaryAbsenceSummaryResponse(),
     )
@@ -1164,9 +1164,9 @@ class TapAllPrisonersReconciliationIntTest(
   }
 
   private fun stubDifferenceIdsEmpty(offenderNo: String = "A0001TZ") {
-    nomisApi.stubGetTemporaryAbsencePrisonerSummaryIds(
+    nomisApi.stubGetTapIds(
       offenderNo = offenderNo,
-      response = emptyTemporaryAbsenceSummaryIdsResponse(),
+      response = emptyTapsIdsResponse(),
     )
     dpsApi.stubGetTapReconciliationDetail(
       personIdentifier = offenderNo,
@@ -1179,10 +1179,10 @@ class TapAllPrisonersReconciliationIntTest(
   }
 }
 
-private fun emptyTemporaryAbsenceSummaryResponse() = OffenderTemporaryAbsenceSummaryResponse(
-  applications = Applications(count = 0),
-  scheduledOutMovements = ScheduledOut(count = 0),
-  movements = Movements(
+private fun emptyTemporaryAbsenceSummaryResponse() = TapSummary(
+  applications = ApplicationSummary(count = 0),
+  scheduledOuts = ScheduledOutSummary(count = 0),
+  movements = MovementSummary(
     count = 0,
     scheduled = MovementsByDirection(outCount = 0, inCount = 0),
     unscheduled = MovementsByDirection(outCount = 0, inCount = 0),
@@ -1198,9 +1198,8 @@ private fun emptyPersonTapCounts() = PersonTapCounts(
   ),
 )
 
-private fun emptyTemporaryAbsenceSummaryIdsResponse() = OffenderTemporaryAbsenceIdsResponse(
+private fun emptyTapsIdsResponse() = OffenderTapsIdsResponse(
   applicationIds = listOf(),
-  scheduleIds = listOf(),
   scheduleOutIds = listOf(),
   scheduleInIds = listOf(),
   scheduledMovementOutIds = listOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiMockServer.kt
@@ -6,22 +6,22 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Absence
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Applications
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ApplicationSummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.BookingTemporaryAbsences
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTemporaryAbsenceRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTemporaryAbsenceResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTemporaryAbsenceReturnRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTemporaryAbsenceReturnResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Movements
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTapMovementIn
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTapMovementInResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTapMovementOut
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateTapMovementOutResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.MovementSummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.MovementsByDirection
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.NomisAudit
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceId
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceIdsResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsenceSummaryResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTapMovementId
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTapsIdsResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderTemporaryAbsencesResponse
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ScheduledOut
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ScheduledOutSummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ScheduledTemporaryAbsence
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.ScheduledTemporaryAbsenceReturn
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.TapSummary
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.TemporaryAbsence
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.TemporaryAbsenceApplication
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.TemporaryAbsenceReturn
@@ -83,11 +83,11 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
 
     fun upsertTapScheduleOutResponse(eventId: Long = 131415, addressId: Long = 77, addressOwnerClass: String = "OFF") = UpsertTapScheduleOutResponse(12345, 56789, eventId, addressId, addressOwnerClass)
 
-    fun createTemporaryAbsenceRequest(scheduledTemporaryAbsenceId: Long = 131415) = CreateTemporaryAbsenceRequest(
+    fun createTapMovementOut(tapScheduleOutId: Long = 131415) = CreateTapMovementOut(
       movementDate = now.toLocalDate(),
       movementTime = now,
       movementReason = "C5",
-      scheduledTemporaryAbsenceId = scheduledTemporaryAbsenceId,
+      tapScheduleOutId = tapScheduleOutId,
       arrestAgency = "POL",
       escort = "U",
       escortText = "Temporary absence escort text",
@@ -98,13 +98,13 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
       toAddressId = 76543,
     )
 
-    fun createTemporaryAbsenceResponse(bookingId: Long = 12345, movementSequence: Int = 2) = CreateTemporaryAbsenceResponse(bookingId, movementSequence)
+    fun createTapMovementOutResponse(bookingId: Long = 12345, movementSequence: Int = 2) = CreateTapMovementOutResponse(bookingId, movementSequence)
 
-    fun createTemporaryAbsenceReturnRequest() = CreateTemporaryAbsenceReturnRequest(
+    fun createTapMovementIn() = CreateTapMovementIn(
       movementDate = tomorrow.toLocalDate(),
       movementTime = tomorrow,
       movementReason = "C5",
-      scheduledTemporaryAbsenceReturnId = 161718,
+      tapScheduleInId = 161718,
       arrestAgency = "POL",
       escort = "U",
       escortText = "Temporary absence return escort text",
@@ -114,27 +114,26 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
       fromAddressId = 76543,
     )
 
-    fun createTemporaryAbsenceReturnResponse(bookingId: Long = 12345, movementSequence: Int = 3) = CreateTemporaryAbsenceReturnResponse(bookingId, movementSequence)
+    fun createTapMovementInResponse(bookingId: Long = 12345, movementSequence: Int = 3) = CreateTapMovementInResponse(bookingId, movementSequence)
 
-    fun createTemporaryAbsenceSummaryResponse() = OffenderTemporaryAbsenceSummaryResponse(
-      applications = Applications(count = 1),
-      scheduledOutMovements = ScheduledOut(count = 2),
-      movements = Movements(
+    fun createTapSummary() = TapSummary(
+      applications = ApplicationSummary(count = 1),
+      scheduledOuts = ScheduledOutSummary(count = 2),
+      movements = MovementSummary(
         count = 18,
         scheduled = MovementsByDirection(outCount = 3, inCount = 4),
         unscheduled = MovementsByDirection(outCount = 5, inCount = 6),
       ),
     )
 
-    fun temporaryAbsenceSummaryIdsResponse() = OffenderTemporaryAbsenceIdsResponse(
+    fun tapIdsResponse() = OffenderTapsIdsResponse(
       applicationIds = listOf(1111),
-      scheduleIds = listOf(),
       scheduleOutIds = listOf(2222),
       scheduleInIds = listOf(9999),
-      scheduledMovementOutIds = listOf(OffenderTemporaryAbsenceId(12345, 3)),
-      scheduledMovementInIds = listOf(OffenderTemporaryAbsenceId(12345, 4)),
-      unscheduledMovementOutIds = listOf(OffenderTemporaryAbsenceId(12345, 5)),
-      unscheduledMovementInIds = listOf(OffenderTemporaryAbsenceId(12345, 6)),
+      scheduledMovementOutIds = listOf(OffenderTapMovementId(12345, 3)),
+      scheduledMovementInIds = listOf(OffenderTapMovementId(12345, 4)),
+      unscheduledMovementOutIds = listOf(OffenderTapMovementId(12345, 5)),
+      unscheduledMovementInIds = listOf(OffenderTapMovementId(12345, 6)),
     )
 
     fun bookingTemporaryAbsences(
@@ -388,12 +387,12 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun stubCreateTemporaryAbsence(
+  fun stubCreateTapMovementOut(
     offenderNo: String = "A1234BC",
-    response: CreateTemporaryAbsenceResponse = createTemporaryAbsenceResponse(),
+    response: CreateTapMovementOutResponse = createTapMovementOutResponse(),
   ) {
     NomisApiExtension.nomisApi.stubFor(
-      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence"))
+      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/taps/movement/out"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -403,13 +402,13 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun stubCreateTemporaryAbsence(
+  fun stubCreateTapMovementOut(
     offenderNo: String = "A1234BC",
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
     NomisApiExtension.nomisApi.stubFor(
-      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence"))
+      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/taps/movement/out"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -419,12 +418,12 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun stubCreateTemporaryAbsenceReturn(
+  fun stubCreateTapMovementIn(
     offenderNo: String = "A1234BC",
-    response: CreateTemporaryAbsenceReturnResponse = createTemporaryAbsenceReturnResponse(),
+    response: CreateTapMovementInResponse = createTapMovementInResponse(),
   ) {
     NomisApiExtension.nomisApi.stubFor(
-      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence-return"))
+      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/taps/movement/in"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -434,13 +433,13 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun stubCreateTemporaryAbsenceReturn(
+  fun stubCreateTapMovementIn(
     offenderNo: String = "A1234BC",
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
     NomisApiExtension.nomisApi.stubFor(
-      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/temporary-absence-return"))
+      WireMock.post(WireMock.urlEqualTo("/movements/$offenderNo/taps/movement/in"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -450,12 +449,12 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun stubGetTemporaryAbsencePrisonerSummary(
+  fun stubGetTapCounts(
     offenderNo: String = "A1234BC",
-    response: OffenderTemporaryAbsenceSummaryResponse = createTemporaryAbsenceSummaryResponse(),
+    response: TapSummary = createTapSummary(),
   ) {
     NomisApiExtension.nomisApi.stubFor(
-      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/summary"))
+      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/taps/summary"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -465,13 +464,13 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun stubGetTemporaryAbsencePrisonerSummary(
+  fun stubGetTapCounts(
     offenderNo: String = "A1234BC",
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
     NomisApiExtension.nomisApi.stubFor(
-      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/summary"))
+      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/taps/summary"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -481,12 +480,12 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun stubGetTemporaryAbsencePrisonerSummaryIds(
+  fun stubGetTapIds(
     offenderNo: String = "A1234BC",
-    response: OffenderTemporaryAbsenceIdsResponse = temporaryAbsenceSummaryIdsResponse(),
+    response: OffenderTapsIdsResponse = tapIdsResponse(),
   ) {
     NomisApiExtension.nomisApi.stubFor(
-      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/ids"))
+      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/taps/ids"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -496,13 +495,13 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun stubGetTemporaryAbsencePrisonerSummaryIds(
+  fun stubGetTapIds(
     offenderNo: String = "A1234BC",
     status: HttpStatus,
     error: ErrorResponse = ErrorResponse(status),
   ) {
     NomisApiExtension.nomisApi.stubFor(
-      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/temporary-absences/ids"))
+      WireMock.get(WireMock.urlEqualTo("/movements/$offenderNo/taps/ids"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/taps/TapNomisApiServiceTest.kt
@@ -20,8 +20,8 @@ import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.SpringAPIServiceTest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.createTemporaryAbsenceRequest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.createTemporaryAbsenceReturnRequest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.createTapMovementIn
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.createTapMovementOut
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.upsertTapApplicationRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.movements.taps.TapNomisApiMockServer.Companion.upsertTapScheduleOut
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.RetryApiService
@@ -130,9 +130,9 @@ class TapNomisApiServiceTest {
     inner class CreateTemporaryAbsence {
       @Test
       fun `will pass oath2 token to service`() = runTest {
-        mockServer.stubCreateTemporaryAbsence()
+        mockServer.stubCreateTapMovementOut()
 
-        apiService.createTemporaryAbsence("A1234BC", createTemporaryAbsenceRequest())
+        apiService.createTapMovementOut("A1234BC", createTapMovementOut())
 
         mockServer.verify(
           postRequestedFor(anyUrl())
@@ -142,12 +142,12 @@ class TapNomisApiServiceTest {
 
       @Test
       fun `will call create endpoint`() = runTest {
-        mockServer.stubCreateTemporaryAbsence()
+        mockServer.stubCreateTapMovementOut()
 
-        apiService.createTemporaryAbsence("A1234BC", createTemporaryAbsenceRequest())
+        apiService.createTapMovementOut("A1234BC", createTapMovementOut())
 
         mockServer.verify(
-          postRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/temporary-absence"))
+          postRequestedFor(urlPathEqualTo("/movements/A1234BC/taps/movement/out"))
             .withRequestBody(
               matchingJsonPath("movementReason", equalTo("C5")),
             ),
@@ -156,10 +156,10 @@ class TapNomisApiServiceTest {
 
       @Test
       fun `will throw if error`() = runTest {
-        mockServer.stubCreateTemporaryAbsence(status = INTERNAL_SERVER_ERROR)
+        mockServer.stubCreateTapMovementOut(status = INTERNAL_SERVER_ERROR)
 
         assertThrows<WebClientResponseException.InternalServerError> {
-          apiService.createTemporaryAbsence("A1234BC", createTemporaryAbsenceRequest())
+          apiService.createTapMovementOut("A1234BC", createTapMovementOut())
         }
       }
     }
@@ -172,9 +172,9 @@ class TapNomisApiServiceTest {
     inner class CreateTemporaryAbsenceReturn {
       @Test
       fun `will pass oath2 token to service`() = runTest {
-        mockServer.stubCreateTemporaryAbsenceReturn()
+        mockServer.stubCreateTapMovementIn()
 
-        apiService.createTemporaryAbsenceReturn("A1234BC", createTemporaryAbsenceReturnRequest())
+        apiService.createTapMovementIn("A1234BC", createTapMovementIn())
 
         mockServer.verify(
           postRequestedFor(anyUrl())
@@ -184,12 +184,12 @@ class TapNomisApiServiceTest {
 
       @Test
       fun `will call create endpoint`() = runTest {
-        mockServer.stubCreateTemporaryAbsenceReturn()
+        mockServer.stubCreateTapMovementIn()
 
-        apiService.createTemporaryAbsenceReturn("A1234BC", createTemporaryAbsenceReturnRequest())
+        apiService.createTapMovementIn("A1234BC", createTapMovementIn())
 
         mockServer.verify(
-          postRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/temporary-absence-return"))
+          postRequestedFor(urlPathEqualTo("/movements/A1234BC/taps/movement/in"))
             .withRequestBody(
               matchingJsonPath("movementReason", equalTo("C5")),
             ),
@@ -198,10 +198,10 @@ class TapNomisApiServiceTest {
 
       @Test
       fun `will throw if error`() = runTest {
-        mockServer.stubCreateTemporaryAbsenceReturn(status = INTERNAL_SERVER_ERROR)
+        mockServer.stubCreateTapMovementIn(status = INTERNAL_SERVER_ERROR)
 
         assertThrows<WebClientResponseException.InternalServerError> {
-          apiService.createTemporaryAbsenceReturn("A1234BC", createTemporaryAbsenceReturnRequest())
+          apiService.createTapMovementIn("A1234BC", createTapMovementIn())
         }
       }
     }
@@ -211,9 +211,9 @@ class TapNomisApiServiceTest {
   inner class TemporaryAbsencePrisonerSummary {
     @Test
     fun `will pass oath2 token to service`() = runTest {
-      mockServer.stubGetTemporaryAbsencePrisonerSummary()
+      mockServer.stubGetTapCounts()
 
-      apiService.getTemporaryAbsenceSummary("A1234BC")
+      apiService.getTapCounts("A1234BC")
 
       mockServer.verify(
         getRequestedFor(anyUrl())
@@ -223,21 +223,21 @@ class TapNomisApiServiceTest {
 
     @Test
     fun `will call get endpoint`() = runTest {
-      mockServer.stubGetTemporaryAbsencePrisonerSummary()
+      mockServer.stubGetTapCounts()
 
-      apiService.getTemporaryAbsenceSummary("A1234BC")
+      apiService.getTapCounts("A1234BC")
 
       mockServer.verify(
-        getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/summary")),
+        getRequestedFor(urlPathEqualTo("/movements/A1234BC/taps/summary")),
       )
     }
 
     @Test
     fun `will throw if error`() = runTest {
-      mockServer.stubGetTemporaryAbsencePrisonerSummary(status = INTERNAL_SERVER_ERROR)
+      mockServer.stubGetTapCounts(status = INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
-        apiService.getTemporaryAbsenceSummary("A1234BC")
+        apiService.getTapCounts("A1234BC")
       }
     }
   }
@@ -246,9 +246,9 @@ class TapNomisApiServiceTest {
   inner class TemporaryAbsencePrisonerSummaryIds {
     @Test
     fun `will pass oath2 token to service`() = runTest {
-      mockServer.stubGetTemporaryAbsencePrisonerSummaryIds()
+      mockServer.stubGetTapIds()
 
-      apiService.getTemporaryAbsenceIds("A1234BC")
+      apiService.getTapIds("A1234BC")
 
       mockServer.verify(
         getRequestedFor(anyUrl())
@@ -258,20 +258,20 @@ class TapNomisApiServiceTest {
 
     @Test
     fun `will call get endpoint`() = runTest {
-      mockServer.stubGetTemporaryAbsencePrisonerSummaryIds()
+      mockServer.stubGetTapIds()
 
-      apiService.getTemporaryAbsenceIds("A1234BC")
+      apiService.getTapIds("A1234BC")
 
       mockServer.verify(
-        getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/ids")),
+        getRequestedFor(urlPathEqualTo("/movements/A1234BC/taps/ids")),
       )
     }
 
     @Test
     fun `will parse response`() = runTest {
-      mockServer.stubGetTemporaryAbsencePrisonerSummaryIds()
+      mockServer.stubGetTapIds()
 
-      apiService.getTemporaryAbsenceIds("A1234BC")
+      apiService.getTapIds("A1234BC")
         .also {
           assertThat(it.applicationIds[0]).isEqualTo(1111)
           assertThat(it.scheduleOutIds[0]).isEqualTo(2222)
@@ -283,16 +283,16 @@ class TapNomisApiServiceTest {
         }
 
       mockServer.verify(
-        getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/ids")),
+        getRequestedFor(urlPathEqualTo("/movements/A1234BC/taps/ids")),
       )
     }
 
     @Test
     fun `will throw if error`() = runTest {
-      mockServer.stubGetTemporaryAbsencePrisonerSummaryIds(status = INTERNAL_SERVER_ERROR)
+      mockServer.stubGetTapIds(status = INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
-        apiService.getTemporaryAbsenceIds("A1234BC")
+        apiService.getTapIds("A1234BC")
       }
     }
   }


### PR DESCRIPTION
Switch to the new NOMIS API for a few more endpoints. This is the only material change - everything else involves switching to the new model and renaming various methods to reflect that.