### PR TITLE
SDIT-3638 Improve manual visit reconciliation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/officialvisits/OfficialVisitsAllReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/officialvisits/OfficialVisitsAllReconciliationService.kt
@@ -146,51 +146,36 @@ class OfficialVisitsAllReconciliationService(
       async { nomisApiService.getOfficialVisitsForPrisoner(offenderNo) } to
         async { dpsApiService.getOfficialVisitsForPrisoner(offenderNo) }
     }.awaitBoth()
-    return checkVisitsMatch(
-      dpsVisits = dpsVisits.map { it.toVisit() },
-      nomisVisits = nomisVisits.map { it.toVisit() },
-      nomisRawVisits = nomisVisits,
-    )
-  }
 
-  private fun checkVisitsMatch(dpsVisits: List<OfficialVisitSummary>, nomisVisits: List<OfficialVisitSummary>, nomisRawVisits: List<OfficialVisitResponse>): List<MismatchVisit> = if (dpsVisits.size != nomisVisits.size) {
-    listOf(
-      MismatchVisit(
-        nomisVisitId = 0,
-        reason = "Counts differ: DPS count is ${dpsVisits.size} and NOMIS count is ${nomisVisits.size}",
-      ),
-    )
-  } else {
-    val sortedDpsVisits = dpsVisits.sortedWith(
-      compareBy(
-        OfficialVisitSummary::startDateTime,
-        OfficialVisitSummary::prisonId,
-        OfficialVisitSummary::visitStatus,
-      ),
-    )
-    val sortedNomisVisits = nomisVisits.sortedWith(
-      compareBy(
-        OfficialVisitSummary::startDateTime,
-        OfficialVisitSummary::prisonId,
-        OfficialVisitSummary::visitStatus,
-      ),
-    )
+    return nomisVisits.map { it.visitId }.mapNotNull { nomisVisitId ->
+      val (nomisVisit, dpsResult: DpsOfficialVisitResult) = nomisVisitToPossibleDpsVisit(nomisVisitId)
+      when (dpsResult) {
+        is NoMapping -> {
+          MismatchVisit(nomisVisitId = nomisVisitId, reason = "official-visit-mapping-missing")
+        }
 
-    val sortedNomisRawVisits = nomisRawVisits.sortedWith(
-      compareBy(
-        OfficialVisitResponse::startDateTime,
-        OfficialVisitResponse::prisonId,
-        { it.visitStatus.code.toDpsVisitStatusType() },
-      ),
-    )
+        is NoOfficialVisit -> {
+          MismatchVisit(nomisVisitId = nomisVisitId, reason = "dps-record-missing")
+        }
 
-    sortedNomisVisits.zip(sortedDpsVisits).mapIndexed { index, (nomisVisit, dpsVisit) ->
-      checkVisitsMatch(
-        nomisVisitId = sortedNomisRawVisits[index].visitId,
-        dpsVisit = dpsVisit,
-        nomisVisit = nomisVisit,
-      )
-    }.filterNotNull()
+        is OfficialVisit -> {
+          checkVisitsMatch(
+            nomisVisitId = nomisVisitId,
+            dpsVisit = dpsResult.visit.toVisit(),
+            nomisVisit = nomisVisit.toVisit(),
+          )
+        }
+      }
+    }.let {
+      if (dpsVisits.size != nomisVisits.size) {
+        it.toMutableList() + MismatchVisit(
+          nomisVisitId = 0,
+          reason = "Counts differ: DPS count is ${dpsVisits.size} and NOMIS count is ${nomisVisits.size}",
+        )
+      } else {
+        it
+      }
+    }
   }
 
   private suspend fun nomisVisitToPossibleDpsVisit(nomisVisitId: Long): Pair<OfficialVisitResponse, DpsOfficialVisitResult> = withContext(Dispatchers.Unconfined) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/integration/IntegrationTestBase.kt
@@ -92,3 +92,7 @@ abstract class IntegrationTestBase {
     }
   }
 }
+
+@Suppress("unused")
+inline fun <reified B : Any> WebTestClient.ResponseSpec.expectBodyResponse(): B = this.expectStatus().is2xxSuccessful.expectBody(B::class.java).returnResult().responseBody!!
+inline fun <reified B : Any> WebTestClient.ResponseSpec.expectBodyListResponse() = this.expectStatus().is2xxSuccessful.expectBodyList(B::class.java).returnResult().responseBody!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/officialvisits/OfficialVisitsReconciliationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/officialvisits/OfficialVisitsReconciliationResourceIntTest.kt
@@ -1,18 +1,18 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.integration.expectBodyListResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.OfficialVisitMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OfficialVisitResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.OfficialVisitsDpsApiMockServer.Companion.syncOfficialVisit
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.OfficialVisitsNomisApiMockServer.Companion.officialVisitResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.officialvisits.model.SyncOfficialVisit
-import java.time.LocalDate
-import java.time.LocalDateTime
 
 class OfficialVisitsReconciliationResourceIntTest(
   @Autowired
@@ -82,29 +82,17 @@ class OfficialVisitsReconciliationResourceIntTest(
 
     @BeforeEach
     fun setUp() {
-      nomisApi.stubGetOfficialVisitsForPrisoner(
-        offenderNo = "A0003TZ",
-        response = listOf(
-          officialVisitResponse().copy(
-            visitId = 4,
-            offenderNo = "A0003TZ",
-            startDateTime = LocalDateTime.parse("2020-01-01T17:01"),
-          ),
-          officialVisitResponse().copy(visitId = 5, offenderNo = "A0003TZ"),
-        ),
-      )
-      dpsApi.stubGetOfficialVisitsForPrisoner(
-        offenderNo = "A0003TZ",
-        response = listOf(
-          syncOfficialVisit().copy(
-            officialVisitId = 4,
-            prisonerNumber = "A0003TZ",
-            startTime = "17:00",
-            visitDate = LocalDate.parse("2020-01-01"),
-          ),
-          syncOfficialVisit().copy(officialVisitId = 5, prisonerNumber = "A0003TZ"),
-        ),
-      )
+      val nomisVisit100 = officialVisitResponse().copy(visitId = 100, prisonId = "WWI")
+      val nomisVisit101 = officialVisitResponse().copy(visitId = 101)
+      val dpsVisit1000 = syncOfficialVisit().copy(officialVisitId = 1000, prisonCode = "BXI")
+      val dpsVisit1001 = syncOfficialVisit().copy(officialVisitId = 1001)
+      val dpsVisit1002 = syncOfficialVisit().copy(officialVisitId = 1002)
+
+      nomisApi.stubGetOfficialVisitsForPrisoner(offenderNo = "A0003TZ", response = listOf(nomisVisit100, nomisVisit101))
+      dpsApi.stubGetOfficialVisitsForPrisoner(offenderNo = "A0003TZ", response = listOf(dpsVisit1000, dpsVisit1001, dpsVisit1002))
+      stubVisits(100, 1000, nomisVisit100, dpsVisit1000)
+      stubVisits(101, 1001, nomisVisit101, dpsVisit1001)
+      dpsApi.stubGetOfficialVisit(1002, response = dpsVisit1002)
     }
 
     @Nested
@@ -137,14 +125,19 @@ class OfficialVisitsReconciliationResourceIntTest(
     inner class HappyPath {
       @Test
       fun `will return mismatches`() {
-        webTestClient.get().uri("/prisoners/A0003TZ/official-visits/reconciliation")
+        val result: List<MismatchVisit> = webTestClient.get().uri("/prisoners/A0003TZ/official-visits/reconciliation")
           .headers(setAuthorisation(roles = listOf("PRISONER_TO_NOMIS__UPDATE__RW")))
           .exchange()
           .expectStatus().isOk
-          .expectBody()
-          .jsonPath("$.size()").isEqualTo(1)
-          .jsonPath("$[0].reason").isEqualTo("different-visit-details")
-          .jsonPath("$[0].nomisVisitId").isEqualTo("4")
+          .expectBodyListResponse()
+
+        assertThat(result).hasSize(2)
+
+        assertThat(result[0].reason).isEqualTo("different-visit-details")
+        assertThat(result[0].nomisVisit?.prisonId).isEqualTo("WWI")
+        assertThat(result[0].dpsVisit?.prisonId).isEqualTo("BXI")
+
+        assertThat(result[1].reason).isEqualTo("Counts differ: DPS count is 3 and NOMIS count is 2")
       }
     }
   }


### PR DESCRIPTION
Use mapping to find correct visit rather the rely on order of visits. A bit efficient but only used for a manual reconciliation