### PR TITLE
SDIT-3660 Removed 409 create alert handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiService.kt
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.alerts
 
+import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.awaitBodilessEntity
-import org.springframework.web.reactive.function.client.awaitBody
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.api.AlertsResourceApi
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.AlertId
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.AlertResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateAlertCode
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateAlertRequest
@@ -16,8 +14,6 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Pr
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateAlertCode
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateAlertRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateAlertType
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.SuccessOrDuplicate
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.awaitSuccessOrDuplicate
 
 @Service
 class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClient: WebClient) {
@@ -26,107 +22,57 @@ class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClien
   suspend fun createAlert(
     offenderNo: String,
     nomisAlert: CreateAlertRequest,
-  ): SuccessOrDuplicate<CreateAlertResponse, AlertId> = with(api) {
-    awaitSuccessOrDuplicate(
-      createAlertRequestConfig(
-        offenderNo = offenderNo,
-        createAlertRequest = nomisAlert,
-      ),
-    )
-  }
+  ): CreateAlertResponse = api.createAlert(
+    offenderNo = offenderNo,
+    createAlertRequest = nomisAlert,
+  ).awaitSingle()
 
-  suspend fun updateAlert(bookingId: Long, alertSequence: Long, nomisAlert: UpdateAlertRequest): AlertResponse = webClient.put().uri(
-    "/prisoners/booking-id/{bookingId}/alerts/{alertSequence}",
-    bookingId,
-    alertSequence,
-  )
-    .bodyValue(nomisAlert)
-    .retrieve()
-    .awaitBody()
+  suspend fun updateAlert(bookingId: Long, alertSequence: Long, nomisAlert: UpdateAlertRequest): AlertResponse = api.updateAlert(
+    bookingId = bookingId,
+    alertSequence = alertSequence,
+    updateAlertRequest = nomisAlert,
+  ).awaitSingle()
 
   suspend fun deleteAlert(bookingId: Long, alertSequence: Long) {
-    webClient.delete().uri(
-      "/prisoners/booking-id/{bookingId}/alerts/{alertSequence}",
-      bookingId,
-      alertSequence,
-    )
-      .retrieve()
-      .awaitBodilessEntity()
+    api.deleteAlert(bookingId, alertSequence).awaitSingle()
   }
 
-  suspend fun resynchroniseAlerts(offenderNo: String, nomisAlerts: List<CreateAlertRequest>): List<CreateAlertResponse> = webClient.post()
-    .uri(
-      "/prisoners/{offenderNo}/alerts/resynchronise",
-      offenderNo,
-    )
-    .bodyValue(nomisAlerts)
-    .retrieve()
-    .awaitBody()
+  suspend fun resynchroniseAlerts(offenderNo: String, nomisAlerts: List<CreateAlertRequest>): List<CreateAlertResponse> = api.resynchroniseAlerts(
+    offenderNo = offenderNo,
+    createAlertRequest = nomisAlerts,
+  ).awaitSingle()
 
-  suspend fun getAlertsForReconciliation(offenderNo: String): PrisonerAlertsResponse = webClient.get().uri(
-    "/prisoners/{offenderNo}/alerts/reconciliation",
-    offenderNo,
-  )
-    .retrieve()
-    .awaitBody()
+  suspend fun getAlertsForReconciliation(offenderNo: String): PrisonerAlertsResponse = api.getActiveAlertsForReconciliation(offenderNo).awaitSingle()
 
   suspend fun createAlertCode(alertCode: CreateAlertCode) {
-    webClient.post()
-      .uri("/alerts/codes")
-      .bodyValue(alertCode)
-      .retrieve()
-      .awaitBodilessEntity()
+    api.createAlertCode(alertCode).awaitSingle()
   }
 
   suspend fun updateAlertCode(code: String, alertCode: UpdateAlertCode) {
-    webClient.put()
-      .uri("/alerts/codes/{code}", code)
-      .bodyValue(alertCode)
-      .retrieve()
-      .awaitBodilessEntity()
+    api.updateAlertCode(code, alertCode).awaitSingle()
   }
 
   suspend fun deactivateAlertCode(code: String) {
-    webClient.put()
-      .uri("/alerts/codes/{code}/deactivate", code)
-      .retrieve()
-      .awaitBodilessEntity()
+    api.deactivateAlertCode(code).awaitSingle()
   }
 
   suspend fun reactivateAlertCode(code: String) {
-    webClient.put()
-      .uri("/alerts/codes/{code}/reactivate", code)
-      .retrieve()
-      .awaitBodilessEntity()
+    api.reactivateAlertCode(code).awaitSingle()
   }
 
   suspend fun createAlertType(alertType: CreateAlertType) {
-    webClient.post()
-      .uri("/alerts/types")
-      .bodyValue(alertType)
-      .retrieve()
-      .awaitBodilessEntity()
+    api.createAlertType(alertType).awaitSingle()
   }
 
   suspend fun updateAlertType(code: String, alertType: UpdateAlertType) {
-    webClient.put()
-      .uri("/alerts/types/{code}", code)
-      .bodyValue(alertType)
-      .retrieve()
-      .awaitBodilessEntity()
+    api.updateAlertType(code, alertType).awaitSingle()
   }
 
   suspend fun deactivateAlertType(code: String) {
-    webClient.put()
-      .uri("/alerts/types/{code}/deactivate", code)
-      .retrieve()
-      .awaitBodilessEntity()
+    api.deactivateAlertType(code).awaitSingle()
   }
 
   suspend fun reactivateAlertType(code: String) {
-    webClient.put()
-      .uri("/alerts/types/{code}/reactivate", code)
-      .retrieve()
-      .awaitBodilessEntity()
+    api.reactivateAlertType(code).awaitSingle()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsService.kt
@@ -49,26 +49,14 @@ class AlertsService(
         transform {
           dpsApiService.getAlert(dpsAlertId)
             .let { dpsAlert ->
-              val nomisAlertResponse = nomisApiService.createAlert(offenderNo, dpsAlert.toNomisCreateRequest())
-              if (nomisAlertResponse.isDuplicate) {
-                val nomisAlertId = nomisAlertResponse.duplicateResponse!!
-                AlertMappingDto(
-                  dpsAlertId = dpsAlertId,
-                  nomisBookingId = nomisAlertId.moreInfo.bookingId,
-                  nomisAlertSequence = nomisAlertId.moreInfo.sequence,
-                  offenderNo = offenderNo,
-                  mappingType = AlertMappingDto.MappingType.DPS_CREATED,
-                )
-              } else {
-                val nomisAlert = nomisAlertResponse.successResponse!!
-                AlertMappingDto(
-                  dpsAlertId = dpsAlertId,
-                  nomisBookingId = nomisAlert.bookingId,
-                  nomisAlertSequence = nomisAlert.alertSequence,
-                  offenderNo = offenderNo,
-                  mappingType = AlertMappingDto.MappingType.DPS_CREATED,
-                )
-              }
+              val nomisAlert = nomisApiService.createAlert(offenderNo, dpsAlert.toNomisCreateRequest())
+              AlertMappingDto(
+                dpsAlertId = dpsAlertId,
+                nomisBookingId = nomisAlert.bookingId,
+                nomisAlertSequence = nomisAlert.alertSequence,
+                offenderNo = offenderNo,
+                mappingType = AlertMappingDto.MappingType.DPS_CREATED,
+              )
             }
         }
         saveMapping { mappingApiService.createMapping(it) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsNomisApiServiceTest.kt
@@ -14,13 +14,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.SpringAPIServiceTest
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.AlertId
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CodeDescription
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateAlertCode
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateAlertRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateAlertResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.CreateAlertType
-import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.DuplicateAlertErrorResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateAlertCode
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateAlertRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateAlertType
@@ -72,25 +70,10 @@ class AlertsNomisApiServiceTest {
         ),
       )
 
-      val nomisAlert = apiService.createAlert(offenderNo = "A1234KT", nomisAlert = createAlertRequest()).successResponse!!
+      val nomisAlert = apiService.createAlert(offenderNo = "A1234KT", nomisAlert = createAlertRequest())
 
       assertThat(nomisAlert.bookingId).isEqualTo(1234567)
       assertThat(nomisAlert.alertSequence).isEqualTo(3)
-    }
-
-    @Test
-    fun `will return existing NOMIS alert id`() = runTest {
-      alertsNomisApiMockServer.stubPostAlert(
-        offenderNo = "A1234KT",
-        errorResponse = DuplicateAlertErrorResponse(
-          moreInfo = AlertId(bookingId = 1234567, sequence = 3),
-        ),
-      )
-
-      val nomisDuplicateAlert = apiService.createAlert(offenderNo = "A1234KT", nomisAlert = createAlertRequest()).duplicateResponse!!
-
-      assertThat(nomisDuplicateAlert.moreInfo.bookingId).isEqualTo(1234567)
-      assertThat(nomisDuplicateAlert.moreInfo.sequence).isEqualTo(3)
     }
 
     private fun createAlertRequest(): CreateAlertRequest = CreateAlertRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/alerts/AlertsToNomisIntTest.kt
@@ -8,10 +8,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
 import org.assertj.core.api.Assertions.assertThat
-import org.awaitility.kotlin.await
-import org.awaitility.kotlin.matches
-import org.awaitility.kotlin.untilAsserted
-import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -32,9 +28,8 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.Al
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.AlertId
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.DuplicateAlertErrorResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.withRequestBodyJsonPath
-import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 
 class AlertsToNomisIntTest : SqsIntegrationTestBase() {
   @Autowired
@@ -197,47 +192,36 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
           fun setUp() {
             alertsMappingApi.stubPostMappingFollowedBySuccess(HttpStatus.INTERNAL_SERVER_ERROR)
             publishCreateAlertDomainEvent(offenderNo = offenderNo, alertUuid = dpsAlertId)
+            waitForAnyProcessingToComplete("alert-create-success")
           }
 
           @Test
           fun `will eventually send telemetry for success`() {
-            await untilAsserted {
-              verify(telemetryClient).trackEvent(
-                eq("alert-create-success"),
-                any(),
-                isNull(),
-              )
-            }
+            verify(telemetryClient).trackEvent(
+              eq("alert-create-success"),
+              any(),
+              isNull(),
+            )
           }
 
           @Test
           fun `will create the alert in NOMIS once`() {
-            await untilAsserted {
-              verify(telemetryClient).trackEvent(
-                eq("alert-create-success"),
-                any(),
-                isNull(),
-              )
-            }
-
             alertsNomisApi.verify(1, postRequestedFor(urlEqualTo("/prisoners/$offenderNo/alerts")))
           }
 
           @Test
           fun `telemetry will contain key facts about the alert created`() {
-            await untilAsserted {
-              verify(telemetryClient).trackEvent(
-                eq("alert-create-success"),
-                check {
-                  assertThat(it).containsEntry("dpsAlertId", dpsAlertId)
-                  assertThat(it).containsEntry("offenderNo", offenderNo)
-                  assertThat(it).containsEntry("alertCode", "HPI")
-                  assertThat(it).containsEntry("nomisAlertSequence", "$nomisAlertSequence")
-                  assertThat(it).containsEntry("nomisBookingId", "$nomisBookingId")
-                },
-                isNull(),
-              )
-            }
+            verify(telemetryClient).trackEvent(
+              eq("alert-create-success"),
+              check {
+                assertThat(it).containsEntry("dpsAlertId", dpsAlertId)
+                assertThat(it).containsEntry("offenderNo", offenderNo)
+                assertThat(it).containsEntry("alertCode", "HPI")
+                assertThat(it).containsEntry("nomisAlertSequence", "$nomisAlertSequence")
+                assertThat(it).containsEntry("nomisBookingId", "$nomisBookingId")
+              },
+              isNull(),
+            )
           }
         }
 
@@ -248,21 +232,11 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
           fun setUp() {
             alertsMappingApi.stubPostMapping(HttpStatus.INTERNAL_SERVER_ERROR)
             publishCreateAlertDomainEvent(offenderNo = offenderNo, alertUuid = dpsAlertId)
-          }
-
-          @Test
-          fun `will add message to dead letter queue`() {
-            await untilCallTo {
-              awsSqsAlertsDlqClient!!.countAllMessagesOnQueue(alertsDlqUrl!!).get()
-            } matches { it == 1 }
+            waitForAnyProcessingToComplete("RETRY_CREATE_MAPPING-sent-to-dlq")
           }
 
           @Test
           fun `will create the alert in NOMIS once`() {
-            await untilCallTo {
-              awsSqsAlertsDlqClient!!.countAllMessagesOnQueue(alertsDlqUrl!!).get()
-            } matches { it == 1 }
-
             alertsNomisApi.verify(1, postRequestedFor(urlEqualTo("/prisoners/$offenderNo/alerts")))
           }
         }
@@ -284,7 +258,6 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
               dpsAlertId = dpsAlertId,
               nomisBookingId = nomisBookingId,
               offenderNo = "A1234AA",
-              // TODO
               nomisAlertSequence = nomisAlertSequence,
               mappingType = AlertMappingDto.MappingType.DPS_CREATED,
             ),
@@ -305,8 +278,8 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
       }
 
       @Nested
-      @DisplayName("when alert has already been created in NOMIS but mapping does not exist")
-      inner class WhenAlertAlreadyCreatedWithNoMapping {
+      @DisplayName("when alert has already been created in NOMIS")
+      inner class WhenAlertAlreadyCreatedInNOMIS {
         private val dpsAlertId = UUID.randomUUID().toString()
         private val nomisBookingId = 43217L
         private val nomisAlertSequence = 3L
@@ -334,20 +307,20 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
               moreInfo = AlertId(bookingId = nomisBookingId, sequence = nomisAlertSequence),
             ),
           )
-          alertsMappingApi.stubPostMapping()
           publishCreateAlertDomainEvent(offenderNo = offenderNo, alertUuid = dpsAlertId)
-          waitForAnyProcessingToComplete()
+          waitForAnyProcessingToComplete("person.alert.created-sent-to-dlq")
         }
 
         @Test
-        fun `will create a mapping between the NOMIS and DPS ids`() {
-          alertsMappingApi.verify(
-            postRequestedFor(urlEqualTo("/mapping/alerts"))
-              .withRequestBodyJsonPath("offenderNo", offenderNo)
-              .withRequestBodyJsonPath("mappingType", "DPS_CREATED")
-              .withRequestBodyJsonPath("dpsAlertId", dpsAlertId)
-              .withRequestBodyJsonPath("nomisAlertSequence", nomisAlertSequence)
-              .withRequestBodyJsonPath("nomisBookingId", nomisBookingId),
+        fun `telemetry will contain key facts about the alert failure`() {
+          verify(telemetryClient, times(2)).trackEvent(
+            eq("alert-create-failed"),
+            check {
+              assertThat(it).containsEntry("dpsAlertId", dpsAlertId)
+              assertThat(it).containsEntry("offenderNo", offenderNo)
+              assertThat(it).containsEntry("alertCode", "HPI")
+            },
+            isNull(),
           )
         }
       }
@@ -391,24 +364,16 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
         fun setUp() {
           alertsMappingApi.stubGetByDpsId(HttpStatus.NOT_FOUND)
           publishUpdateAlertDomainEvent()
-        }
-
-        @Test
-        fun `will treat this as an error and message will go on DLQ`() {
-          await untilCallTo {
-            awsSqsAlertsDlqClient!!.countAllMessagesOnQueue(alertsDlqUrl!!).get()
-          } matches { it == 1 }
+          waitForAnyProcessingToComplete("person.alert.updated-sent-to-dlq")
         }
 
         @Test
         fun `will send telemetry event showing it failed to update for each retry`() {
-          await untilAsserted {
-            verify(telemetryClient, times(3)).trackEvent(
-              eq("alert-updated-failed"),
-              any(),
-              isNull(),
-            )
-          }
+          verify(telemetryClient, times(2)).trackEvent(
+            eq("alert-updated-failed"),
+            any(),
+            isNull(),
+          )
         }
       }
 
@@ -428,7 +393,6 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
               dpsAlertId = dpsAlertId,
               nomisBookingId = nomisBookingId,
               offenderNo = "A1234AA",
-              // TODO
               nomisAlertSequence = nomisAlertSequence,
               mappingType = AlertMappingDto.MappingType.DPS_CREATED,
             ),
@@ -574,7 +538,6 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
               dpsAlertId = dpsAlertId,
               nomisBookingId = nomisBookingId,
               offenderNo = "A1234AA",
-              // TODO
               nomisAlertSequence = nomisAlertSequence,
               mappingType = AlertMappingDto.MappingType.DPS_CREATED,
             ),
@@ -641,7 +604,6 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
               dpsAlertId = dpsAlertId,
               nomisBookingId = nomisBookingId,
               offenderNo = "A1234AA",
-              // TODO
               nomisAlertSequence = nomisAlertSequence,
               mappingType = AlertMappingDto.MappingType.DPS_CREATED,
             ),
@@ -649,13 +611,7 @@ class AlertsToNomisIntTest : SqsIntegrationTestBase() {
           alertsNomisApi.stubDeleteAlert(bookingId = nomisBookingId, alertSequence = nomisAlertSequence)
           alertsMappingApi.stubDeleteByDpsId(status = HttpStatus.INTERNAL_SERVER_ERROR)
           publishDeleteAlertDomainEvent(alertUuid = dpsAlertId, offenderNo = offenderNo)
-          await untilAsserted {
-            verify(telemetryClient).trackEvent(
-              eq("alert-deleted-success"),
-              any(),
-              isNull(),
-            )
-          }
+          waitForAnyProcessingToComplete("alert-deleted-success")
         }
 
         @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -209,7 +209,7 @@ hmpps.sqs:
           "prisoner-alerts.alert-type-reactivated",
           "prisoner-alerts.alert-type-updated"
         ]}
-      dlqMaxReceiveCount: 3
+      dlqMaxReceiveCount: 2
       visibilityTimeout: 120
     casenotes:
       queueName: "casenotes-${random.uuid}"


### PR DESCRIPTION
We tried to create an alert mapping when a duplicate alert in NOMIS was detected. This would mean a double POST to NOMS API would be handled automatcially.

This caused more issues then it solved; since you can have the same alert code  in NOMIS multiple times but only one can be active.

This caused timing issues where an alert can be made inactive and the same alert code created around the same time. If the events are processed out of order the mappings ends up wrong.

Also refactored the webClient to use generated API.

Also refactored test to handle DLQ scenarios better