### PR TITLE
SDIT-3704 Allow null start dates for key dates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsService.kt
@@ -88,7 +88,7 @@ class SentencingAdjustmentsService(
       CreateKeyDateAdjustmentRequest(
         adjustmentTypeCode = CreateKeyDateAdjustmentRequest.AdjustmentTypeCode.valueOf(adjustment.adjustmentType.value),
         adjustmentDate = adjustment.adjustmentDate ?: LocalDate.now(),
-        adjustmentFromDate = adjustment.adjustmentFromDate!!,
+        adjustmentFromDate = adjustment.adjustmentFromDate ?: adjustment.adjustmentDate ?: LocalDate.now(),
         adjustmentDays = adjustment.adjustmentDays.toLong(),
         comment = adjustment.comment,
       ),
@@ -178,7 +178,7 @@ class SentencingAdjustmentsService(
         UpdateKeyDateAdjustmentRequest(
           adjustmentTypeCode = UpdateKeyDateAdjustmentRequest.AdjustmentTypeCode.valueOf(adjustment.adjustmentType.value),
           adjustmentDate = adjustment.adjustmentDate ?: LocalDate.now(),
-          adjustmentFromDate = adjustment.adjustmentFromDate!!,
+          adjustmentFromDate = adjustment.adjustmentFromDate ?: adjustment.adjustmentDate ?: LocalDate.now(),
           adjustmentDays = adjustment.adjustmentDays.toLong(),
           comment = adjustment.comment,
           active = active,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/sentencing/SentencingAdjustmentsToNomisIntTest.kt
@@ -174,6 +174,41 @@ class SentencingAdjustmentsToNomisTest : SqsIntegrationTestBase() {
       }
 
       @Nested
+      inner class WhenSREMAdjustment {
+        private val nomisAdjustmentId = 98765L
+
+        @BeforeEach
+        fun setUp() {
+          nomisApi.stubKeyDateAdjustmentCreate(
+            bookingId = BOOKING_ID,
+            adjustmentId = nomisAdjustmentId,
+          )
+
+          sentencingAdjustmentsApi.stubAdjustmentGet(
+            adjustmentId = ADJUSTMENT_ID,
+            sentenceSequence = null,
+            active = true,
+            adjustmentDays = 99,
+            adjustmentDate = "2022-01-01",
+            adjustmentType = "SREM",
+            adjustmentFromDate = null,
+            comment = "Meritorious conduct",
+            bookingId = BOOKING_ID,
+          )
+          publishCreateAdjustmentDomainEvent().also { waitForAnyProcessingToComplete() }
+        }
+
+        @Test
+        fun `will create a sentence adjustment in NOMIS with start date equal to adjustment date`() {
+          nomisApi.verify(
+            postRequestedFor(urlEqualTo("/prisoners/booking-id/$BOOKING_ID/adjustments"))
+              .withRequestBody(matchingJsonPath("adjustmentDate", equalTo("2022-01-01")))
+              .withRequestBody(matchingJsonPath("adjustmentFromDate", equalTo("2022-01-01"))),
+          )
+        }
+      }
+
+      @Nested
       inner class WhenSentenceSequenceIsNotProvided {
         private val nomisAdjustmentId = 98765L
 


### PR DESCRIPTION
Some key date adjustments - i.e. SREMs have no start date - so just default to adjustment date