### PR TITLE
SDIT-3672 Send courtsentencing.resync.breach-court-appearance.inserted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingService.kt
@@ -71,8 +71,6 @@ import kotlin.collections.plus
 
 typealias MappingSentenceId = uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.SentenceId
 
-private const val DPS_VIDEO_LINK = "1da09b6e-55cb-4838-a157-ee6944f2094c"
-
 @Service
 class CourtSentencingService(
   private val courtSentencingApiService: CourtSentencingApiService,
@@ -686,6 +684,18 @@ class CourtSentencingService(
                 adjustmentIds = listOf(adjustmentId),
               ),
             ),
+          ),
+        )
+      }
+
+      val courtAppearancesRequiringSync = mappingsWrapper.mappings.nomisCourtAppearanceIds
+      courtAppearancesRequiringSync.forEach { courtAppearanceId ->
+        queueService.sendMessageTrackOnFailure(
+          queueId = "fromnomiscourtsentencing",
+          eventType = "courtsentencing.resync.breach-court-appearance.inserted",
+          message = SyncRecallBreachCourtAppearanceEvent(
+            offenderNo = offenderNo,
+            courtAppearanceId = courtAppearanceId,
           ),
         )
       }
@@ -1857,6 +1867,11 @@ data class ClonedCourtCaseDetails(
 data class SentenceIdAndAdjustmentType(
   val sentenceId: SentenceId,
   val adjustmentIds: List<Long>,
+)
+
+data class SyncRecallBreachCourtAppearanceEvent(
+  val offenderNo: String,
+  val courtAppearanceId: Long,
 )
 
 fun BookingCourtCaseCloneResponse.toClonedCourtCaseDetails() = ClonedCourtCaseDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCasesToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCasesToNomisIntTest.kt
@@ -1271,7 +1271,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
             .withRequestBody(
               matchingJsonPath(
                 "courtEventChargesWithOutcomes[0].resultCode1",
-                equalTo(COURT_CHARGE_1_RESULT_CODE.toString()),
+                equalTo(COURT_CHARGE_1_RESULT_CODE),
               ),
             )
             .withRequestBody(
@@ -1283,7 +1283,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
             .withRequestBody(
               matchingJsonPath(
                 "courtEventChargesWithOutcomes[1].resultCode1",
-                equalTo(COURT_CHARGE_2_RESULT_CODE.toString()),
+                equalTo(COURT_CHARGE_2_RESULT_CODE),
               ),
             ),
         )
@@ -1416,7 +1416,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
             .withRequestBody(
               matchingJsonPath(
                 "courtEventChargesWithOutcomes[0].resultCode1",
-                equalTo(COURT_CHARGE_1_RESULT_CODE.toString()),
+                equalTo(COURT_CHARGE_1_RESULT_CODE),
               ),
             )
             .withRequestBody(
@@ -1428,7 +1428,7 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
             .withRequestBody(
               matchingJsonPath(
                 "courtEventChargesWithOutcomes[1].resultCode1",
-                equalTo(COURT_CHARGE_2_RESULT_CODE.toString()),
+                equalTo(COURT_CHARGE_2_RESULT_CODE),
               ),
             ),
         )
@@ -4092,13 +4092,15 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           }
 
           @Test
-          fun `will send message to nomis migration for each sync sentence adjustments that have been activated`() {
+          fun `will send message to nomis migration to sync each adjustment changed and breach hearing created`() {
             await untilAsserted {
-              assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(2)
+              assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(4)
             }
             val rawMessages = fromNomisCourtSentencingQueue.readAtMost10RawMessages()
             val adjustmentMessage1 = rawMessages[0].fromJson<SQSMessage>()
             val adjustmentMessage2 = rawMessages[1].fromJson<SQSMessage>()
+            val breachCourtAppearanceMessage1 = rawMessages[2].fromJson<SQSMessage>()
+            val breachCourtAppearanceMessage2 = rawMessages[3].fromJson<SQSMessage>()
 
             with(adjustmentMessage1) {
               assertThat(Type).isEqualTo("courtsentencing.resync.sentence-adjustments")
@@ -4120,12 +4122,26 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
               assertThat(request.sentences[0].adjustmentIds).hasSize(1)
               assertThat(request.sentences[0].adjustmentIds[0]).isIn(1L, 2L)
             }
+            // shenanigans since the order isn't guaranteed since it comes from a set of Lists
             val firstAdjustmentId =
               adjustmentMessage1.Message.fromJson<SyncSentenceAdjustment>().sentences[0].adjustmentIds[0]
             val secondAdjustmentId =
               adjustmentMessage2.Message.fromJson<SyncSentenceAdjustment>().sentences[0].adjustmentIds[0]
 
             assertThat(firstAdjustmentId).isNotEqualTo(secondAdjustmentId)
+
+            with(breachCourtAppearanceMessage1) {
+              assertThat(this.Type).isEqualTo("courtsentencing.resync.breach-court-appearance.inserted")
+              val request: SyncRecallBreachCourtAppearanceEvent = Message.fromJson()
+              assertThat(request.offenderNo).isEqualTo(OFFENDER_NO)
+              assertThat(request.courtAppearanceId).isEqualTo(101L)
+            }
+            with(breachCourtAppearanceMessage2) {
+              assertThat(this.Type).isEqualTo("courtsentencing.resync.breach-court-appearance.inserted")
+              val request: SyncRecallBreachCourtAppearanceEvent = Message.fromJson()
+              assertThat(request.offenderNo).isEqualTo(OFFENDER_NO)
+              assertThat(request.courtAppearanceId).isEqualTo(102L)
+            }
           }
 
           @Test
@@ -4370,9 +4386,9 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           }
 
           @Test
-          fun `will send message to nomis migration to sync court cases cloned`() {
+          fun `will send message to nomis migration for each adjustments, breach hearing and the case clone`() {
             await untilAsserted {
-              assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(3)
+              assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(4)
             }
             val rawMessages = fromNomisCourtSentencingQueue.readAtMost10RawMessages()
             val sqsMessages: List<SQSMessage> = rawMessages.map { it.fromJson() }
@@ -4392,11 +4408,12 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           @Test
           fun `will send message to nomis migration for each sync sentence adjustments that have been created`() {
             await untilAsserted {
-              assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(3)
+              assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(4)
             }
             val rawMessages = fromNomisCourtSentencingQueue.readAtMost10RawMessages()
             val sqsMessages: List<SQSMessage> = rawMessages.map { it.fromJson() }
             val adjustmentMessages = sqsMessages.filter { it.Type == "courtsentencing.resync.sentence-adjustments" }
+            val breachCourtAppearanceMessages = sqsMessages.filter { it.Type == "courtsentencing.resync.breach-court-appearance.inserted" }
 
             assertThat(adjustmentMessages).hasSize(2)
 
@@ -4429,6 +4446,8 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
             assertThat(firstAdjustmentId).isIn(20001L, 20002L)
             assertThat(secondAdjustmentId).isIn(20001L, 20002L)
             assertThat(firstAdjustmentId).isNotEqualTo(secondAdjustmentId)
+
+            assertThat(breachCourtAppearanceMessages).hasSize(1)
           }
 
           @Test
@@ -4525,9 +4544,9 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           }
 
           @Test
-          fun `will send message to nomis migration for each sync sentence adjustments and the case clone`() {
+          fun `will send message to nomis migration for each adjustments, breach hearing and the case clone`() {
             await untilAsserted {
-              assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(3)
+              assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(4)
             }
           }
         }


### PR DESCRIPTION
For each recall breach hearing created we will send a courtsentencing.resync.breach-court-appearance.inserted to "from-nomis" sync service to sync the court appearance back to DPS

Fixed a few warnings