### PR TITLE
SDIT-3826 Handle breach appearance created by recall update

### DIFF
--- a/openapi-specs/nomis-mapping-service-api-docs.json
+++ b/openapi-specs/nomis-mapping-service-api-docs.json
@@ -7,7 +7,7 @@
       "name" : "HMPPS Digital Studio",
       "email" : "feedback@digital.justice.gov.uk"
     },
-    "version" : "2026-05-19.579.c5af83e"
+    "version" : "2026-05-26.586.31fa57a"
   },
   "servers" : [ {
     "url" : "https://nomis-sync-prisoner-mapping.hmpps.service.justice.gov.uk",
@@ -990,6 +990,68 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapping/court-sentencing/court-appearances/recall/{recall-id}" : {
+      "put" : {
+        "tags" : [ "court-sentencing-mapping-resource" ],
+        "summary" : "Updates new court appearance recall mappings",
+        "description" : "Replaces mappings between nomis Court appearance IDs and DPS Recall ID. Requires ROLE_NOMIS_MAPPING_API__SYNCHRONISATION__RW",
+        "operationId" : "updateCourtAppearanceRecallMapping",
+        "parameters" : [ {
+          "name" : "recall-id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CourtAppearanceRecallMappingsUpdateDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Mappings updated",
+            "content" : { }
+          },
+          "401" : {
+            "description" : "Unauthorized to access this endpoint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Access forbidden for this endpoint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Indicates a duplicate mapping has been rejected. If Error code = 1409 the body will return a DuplicateErrorResponse",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DuplicateMappingErrorResponse"
                 }
               }
             }
@@ -21281,6 +21343,54 @@
         },
         "required" : [ "fromNomisId", "toNomisId" ]
       },
+      "CourtAppearanceRecallMappingsUpdateDto" : {
+        "type" : "object",
+        "description" : "Court appearance recall mappings",
+        "properties" : {
+          "nomisCourtAppearanceIds" : {
+            "type" : "array",
+            "description" : "List of NOMIS court appearance ids",
+            "example" : [ 123456, 789012 ],
+            "items" : {
+              "type" : "integer",
+              "format" : "int64"
+            },
+            "minItems" : 1
+          }
+        },
+        "required" : [ "nomisCourtAppearanceIds" ]
+      },
+      "DuplicateErrorContentObject" : {
+        "type" : "object",
+        "properties" : {
+          "duplicate" : { },
+          "existing" : { }
+        },
+        "required" : [ "duplicate", "existing" ]
+      },
+      "DuplicateMappingErrorResponse" : {
+        "type" : "object",
+        "properties" : {
+          "moreInfo" : {
+            "$ref" : "#/components/schemas/DuplicateErrorContentObject"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "100 CONTINUE", "101 SWITCHING_PROTOCOLS", "102 PROCESSING", "103 EARLY_HINTS", "200 OK", "201 CREATED", "202 ACCEPTED", "203 NON_AUTHORITATIVE_INFORMATION", "204 NO_CONTENT", "205 RESET_CONTENT", "206 PARTIAL_CONTENT", "207 MULTI_STATUS", "208 ALREADY_REPORTED", "226 IM_USED", "300 MULTIPLE_CHOICES", "301 MOVED_PERMANENTLY", "302 FOUND", "303 SEE_OTHER", "304 NOT_MODIFIED", "307 TEMPORARY_REDIRECT", "308 PERMANENT_REDIRECT", "400 BAD_REQUEST", "401 UNAUTHORIZED", "402 PAYMENT_REQUIRED", "403 FORBIDDEN", "404 NOT_FOUND", "405 METHOD_NOT_ALLOWED", "406 NOT_ACCEPTABLE", "407 PROXY_AUTHENTICATION_REQUIRED", "408 REQUEST_TIMEOUT", "409 CONFLICT", "410 GONE", "411 LENGTH_REQUIRED", "412 PRECONDITION_FAILED", "413 CONTENT_TOO_LARGE", "413 PAYLOAD_TOO_LARGE", "414 URI_TOO_LONG", "415 UNSUPPORTED_MEDIA_TYPE", "416 REQUESTED_RANGE_NOT_SATISFIABLE", "417 EXPECTATION_FAILED", "418 I_AM_A_TEAPOT", "421 MISDIRECTED_REQUEST", "422 UNPROCESSABLE_CONTENT", "422 UNPROCESSABLE_ENTITY", "423 LOCKED", "424 FAILED_DEPENDENCY", "425 TOO_EARLY", "426 UPGRADE_REQUIRED", "428 PRECONDITION_REQUIRED", "429 TOO_MANY_REQUESTS", "431 REQUEST_HEADER_FIELDS_TOO_LARGE", "451 UNAVAILABLE_FOR_LEGAL_REASONS", "500 INTERNAL_SERVER_ERROR", "501 NOT_IMPLEMENTED", "502 BAD_GATEWAY", "503 SERVICE_UNAVAILABLE", "504 GATEWAY_TIMEOUT", "505 HTTP_VERSION_NOT_SUPPORTED", "506 VARIANT_ALSO_NEGOTIATES", "507 INSUFFICIENT_STORAGE", "508 LOOP_DETECTED", "509 BANDWIDTH_LIMIT_EXCEEDED", "510 NOT_EXTENDED", "511 NETWORK_AUTHENTICATION_REQUIRED" ]
+          },
+          "errorCode" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "userMessage" : {
+            "type" : "string"
+          },
+          "developerMessage" : {
+            "type" : [ "string", "null" ]
+          }
+        },
+        "required" : [ "errorCode", "moreInfo", "status", "userMessage" ]
+      },
       "BookingCourtMovementMappingsDto" : {
         "type" : "object",
         "description" : "Mappings for a single court movement",
@@ -21663,37 +21773,6 @@
           }
         },
         "required" : [ "mappingType", "nomisId", "vsipId" ]
-      },
-      "DuplicateErrorContentObject" : {
-        "type" : "object",
-        "properties" : {
-          "duplicate" : { },
-          "existing" : { }
-        },
-        "required" : [ "duplicate", "existing" ]
-      },
-      "DuplicateMappingErrorResponse" : {
-        "type" : "object",
-        "properties" : {
-          "moreInfo" : {
-            "$ref" : "#/components/schemas/DuplicateErrorContentObject"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "100 CONTINUE", "101 SWITCHING_PROTOCOLS", "102 PROCESSING", "103 EARLY_HINTS", "200 OK", "201 CREATED", "202 ACCEPTED", "203 NON_AUTHORITATIVE_INFORMATION", "204 NO_CONTENT", "205 RESET_CONTENT", "206 PARTIAL_CONTENT", "207 MULTI_STATUS", "208 ALREADY_REPORTED", "226 IM_USED", "300 MULTIPLE_CHOICES", "301 MOVED_PERMANENTLY", "302 FOUND", "303 SEE_OTHER", "304 NOT_MODIFIED", "307 TEMPORARY_REDIRECT", "308 PERMANENT_REDIRECT", "400 BAD_REQUEST", "401 UNAUTHORIZED", "402 PAYMENT_REQUIRED", "403 FORBIDDEN", "404 NOT_FOUND", "405 METHOD_NOT_ALLOWED", "406 NOT_ACCEPTABLE", "407 PROXY_AUTHENTICATION_REQUIRED", "408 REQUEST_TIMEOUT", "409 CONFLICT", "410 GONE", "411 LENGTH_REQUIRED", "412 PRECONDITION_FAILED", "413 CONTENT_TOO_LARGE", "413 PAYLOAD_TOO_LARGE", "414 URI_TOO_LONG", "415 UNSUPPORTED_MEDIA_TYPE", "416 REQUESTED_RANGE_NOT_SATISFIABLE", "417 EXPECTATION_FAILED", "418 I_AM_A_TEAPOT", "421 MISDIRECTED_REQUEST", "422 UNPROCESSABLE_CONTENT", "422 UNPROCESSABLE_ENTITY", "423 LOCKED", "424 FAILED_DEPENDENCY", "425 TOO_EARLY", "426 UPGRADE_REQUIRED", "428 PRECONDITION_REQUIRED", "429 TOO_MANY_REQUESTS", "431 REQUEST_HEADER_FIELDS_TOO_LARGE", "451 UNAVAILABLE_FOR_LEGAL_REASONS", "500 INTERNAL_SERVER_ERROR", "501 NOT_IMPLEMENTED", "502 BAD_GATEWAY", "503 SERVICE_UNAVAILABLE", "504 GATEWAY_TIMEOUT", "505 HTTP_VERSION_NOT_SUPPORTED", "506 VARIANT_ALSO_NEGOTIATES", "507 INSUFFICIENT_STORAGE", "508 LOOP_DETECTED", "509 BANDWIDTH_LIMIT_EXCEEDED", "510 NOT_EXTENDED", "511 NETWORK_AUTHENTICATION_REQUIRED" ]
-          },
-          "errorCode" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "userMessage" : {
-            "type" : "string"
-          },
-          "developerMessage" : {
-            "type" : [ "string", "null" ]
-          }
-        },
-        "required" : [ "errorCode", "moreInfo", "status", "userMessage" ]
       },
       "VisitSlotMappingDto" : {
         "type" : "object",

--- a/openapi-specs/nomis-prisoner-api-docs.json
+++ b/openapi-specs/nomis-prisoner-api-docs.json
@@ -7,7 +7,7 @@
       "name" : "HMPPS Digital Studio",
       "email" : "feedback@digital.justice.gov.uk"
     },
-    "version" : "2026-05-22.1478.0b0b02d"
+    "version" : "2026-05-26.1480.30cf22d"
   },
   "servers" : [ {
     "url" : "https://nomis-prisoner-api-dev.prison.service.justice.gov.uk",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingMappingService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.prisonertonomisupdate.courtsentencing
 
+import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
@@ -7,9 +8,11 @@ import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import org.springframework.web.reactive.function.client.awaitBody
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodilessEntityOrThrowOnConflict
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.awaitBodyOrNullForNotFound
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.api.CourtSentencingMappingResourceApi
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceRecallMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceRecallMappingsDto
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceRecallMappingsUpdateDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseAllMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseBatchMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseBatchUpdateAndCreateMappingDto
@@ -24,6 +27,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.Se
 class CourtSentencingMappingService(
   @Qualifier("mappingWebClient") private val webClient: WebClient,
 ) {
+  private val api = CourtSentencingMappingResourceApi(webClient)
 
   suspend fun createMapping(request: CourtCaseAllMappingDto) {
     webClient.post()
@@ -60,6 +64,14 @@ class CourtSentencingMappingService(
       .retrieve()
       .awaitBodilessEntityOrThrowOnConflict()
   }
+
+  suspend fun updateAppearanceRecallMappings(recallId: String, request: CourtAppearanceRecallMappingsUpdateDto) {
+    api.updateCourtAppearanceRecallMapping(
+      recallId = recallId,
+      courtAppearanceRecallMappingsUpdateDto = request,
+    ).awaitSingle()
+  }
+
   suspend fun deleteAppearanceRecallMappings(recallId: String) {
     webClient.delete()
       .uri("/mapping/court-sentencing/court-appearances/dps-recall-id/{recallId}", recallId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingNomisApiService.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Se
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateCourtAppearanceResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateCourtCaseRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateRecallRequest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateRecallResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.RetryApiService
 
 @Service
@@ -177,11 +178,11 @@ class CourtSentencingNomisApiService(@Qualifier("nomisApiWebClient") private val
   suspend fun updateRecallSentences(
     offenderNo: String,
     request: UpdateRecallRequest,
-  ): ResponseEntity<Void> = webClient.put()
+  ): UpdateRecallResponse = webClient.put()
     .uri("/prisoners/{offenderNo}/sentences/recall", offenderNo)
     .bodyValue(request)
     .retrieve()
-    .awaitBodilessEntity()
+    .awaitBody()
 
   suspend fun deleteRecallSentences(
     offenderNo: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.court.sentencing.model
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.ParentEntityNotFoundRetry
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceRecallMappingsDto
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceRecallMappingsUpdateDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseAllMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseBatchMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseBatchUpdateAndCreateMappingDto
@@ -91,6 +92,7 @@ class CourtSentencingService(
     COURT_CASE("court-case"),
     COURT_APPEARANCE("court-appearance"),
     COURT_APPEARANCE_RECALL("court-appearance-recall"),
+    COURT_APPEARANCE_RECALL_UPDATE("court-appearance-recall-update"),
     COURT_CHARGE("charge"),
     SENTENCE("sentence"),
     SENTENCE_TERM("sentence-term"),
@@ -721,6 +723,50 @@ class CourtSentencingService(
     }
   }
 
+  suspend fun tryUpdateRecallAppearanceMappings(
+    mappingsWrapper: RecallAppearanceUpdateMappingsWrapper,
+    telemetry: Map<String, String>,
+  ) {
+    try {
+      updateRecallAppearanceMappings(
+        mappingsWrapper = mappingsWrapper,
+      )
+    } catch (e: Exception) {
+      telemetryClient.trackEvent(
+        "recall-mappings-updated-failed",
+        telemetry + ("reason" to (e.message ?: "unknown")),
+        null,
+      )
+      courtSentencingRetryQueueService.sendMessage(
+        mapping = mappingsWrapper,
+        telemetryAttributes = telemetry,
+        entityName = EntityType.COURT_APPEARANCE_RECALL_UPDATE.displayName,
+      )
+    }
+  }
+
+  suspend fun updateRecallAppearanceMappings(
+    mappingsWrapper: RecallAppearanceUpdateMappingsWrapper,
+  ) {
+    courtCaseMappingService.updateAppearanceRecallMappings(
+      recallId = mappingsWrapper.dpsRecallId,
+      request = CourtAppearanceRecallMappingsUpdateDto(
+        nomisCourtAppearanceIds = mappingsWrapper.updatedCourtEventIds + mappingsWrapper.createdCourtEventIds,
+      ),
+    )
+
+    mappingsWrapper.createdCourtEventIds.forEach { courtAppearanceId ->
+      queueService.sendMessageTrackOnFailure(
+        queueId = "fromnomiscourtsentencing",
+        eventType = "courtsentencing.resync.breach-court-appearance.inserted",
+        message = SyncRecallBreachCourtAppearanceEvent(
+          offenderNo = mappingsWrapper.offenderNo,
+          courtAppearanceId = courtAppearanceId,
+        ),
+      )
+    }
+  }
+
   suspend fun tryUpdateCaseMappingsAndNotifyClonedCases(
     mappingsWrapper: CourtCaseBatchUpdateAndCreateMappingsWrapper,
     offenderNo: String,
@@ -830,6 +876,18 @@ class CourtSentencingService(
     }
   }
 
+  suspend fun updateRecallAppearanceMappingsRetry(message: CreateMappingRetryMessage<RecallAppearanceUpdateMappingsWrapper>) = with(message) {
+    updateRecallAppearanceMappings(
+      mappingsWrapper = mapping,
+    ).also {
+      telemetryClient.trackEvent(
+        "court-appearance-recall-update-mapping-retry-success",
+        telemetryAttributes,
+        null,
+      )
+    }
+  }
+
   suspend fun createChargeRetry(message: CreateMappingRetryMessage<CourtChargeMappingDto>) = courtCaseMappingService.createChargeMapping(message.mapping).also {
     telemetryClient.trackEvent(
       "charge-create-mapping-retry-success",
@@ -862,6 +920,10 @@ class CourtSentencingService(
       EntityType.COURT_APPEARANCE.displayName -> createAppearanceMappingsRetry(message.fromJson())
 
       EntityType.COURT_APPEARANCE_RECALL.displayName -> createAppearanceMappingsAndNotifySentenceAdjustmentsAndClonedCasesRetry(
+        message.fromJson(),
+      )
+
+      EntityType.COURT_APPEARANCE_RECALL_UPDATE.displayName -> updateRecallAppearanceMappingsRetry(
         message.fromJson(),
       )
 
@@ -1185,7 +1247,7 @@ class CourtSentencingService(
           getSentenceAndMappings(dpsRemovedSentenceIds).also { telemetryMap.toRemovedTelemetry(it) }
         val breachCourtAppearanceIds =
           courtCaseMappingService.getAppearanceRecallMappings(recallId).map { it.nomisCourtAppearanceId }
-        nomisApiService.updateRecallSentences(
+        val recallUpdateResponse = nomisApiService.updateRecallSentences(
           offenderNo,
           UpdateRecallRequest(
             sentences = sentenceAndMappings.map { it.toRecallRelatedSentenceDetails() },
@@ -1202,6 +1264,16 @@ class CourtSentencingService(
             recallRevocationDate = recall.revocationDate!!,
             beachCourtEventIds = breachCourtAppearanceIds,
           ),
+        )
+
+        tryUpdateRecallAppearanceMappings(
+          mappingsWrapper = RecallAppearanceUpdateMappingsWrapper(
+            createdCourtEventIds = recallUpdateResponse.createdCourtEventIds,
+            updatedCourtEventIds = recallUpdateResponse.updatedCourtEventIds,
+            dpsRecallId = recallId,
+            offenderNo = offenderNo,
+          ),
+          telemetry = telemetryMap,
         )
 
         telemetryClient.trackEvent(
@@ -1853,6 +1925,13 @@ data class RecallAppearanceAndCreateMappingsWrapper(
   val mappings: CourtAppearanceRecallMappingsDto,
   val offenderNo: String,
   val clonedClonedCourtCaseDetails: ClonedCourtCaseDetails?,
+)
+
+data class RecallAppearanceUpdateMappingsWrapper(
+  val createdCourtEventIds: List<Long>,
+  val updatedCourtEventIds: List<Long>,
+  val dpsRecallId: String,
+  val offenderNo: String,
 )
 
 data class ClonedCourtCaseDetails(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCasesToNomisIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtCasesToNomisIntTest.kt
@@ -64,6 +64,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Se
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.SentenceIdAndAdjustmentIds
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.SentenceIdAndAdjustmentsCreated
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateCourtAppearanceResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateRecallResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.sentencing.BOOKING_ID
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -4586,12 +4587,14 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
 
     @Nested
     inner class WhenRecallHasBeenUpdatedInDPS {
+      val dpsRecallId = "dc71f3c5-70d4-4faf-a4a5-ff9662d5f714"
+
       @BeforeEach
       fun setUp() {
         courtSentencingApi.stubGetRecall(
-          "dc71f3c5-70d4-4faf-a4a5-ff9662d5f714",
+          dpsRecallId,
           LegacyRecall(
-            recallUuid = UUID.fromString("dc71f3c5-70d4-4faf-a4a5-ff9662d5f714"),
+            recallUuid = UUID.fromString(dpsRecallId),
             recallType = LegacyRecall.RecallType.FTR_14,
             recallBy = "T.SMITH",
             returnToCustodyDate = null,
@@ -4631,15 +4634,15 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
         )
 
         courtSentencingMappingApi.stubGetAppearanceRecallMappings(
-          "dc71f3c5-70d4-4faf-a4a5-ff9662d5f714",
+          dpsRecallId,
           mappings = listOf(
             CourtAppearanceRecallMappingDto(
               nomisCourtAppearanceId = 101,
-              dpsRecallId = "dc71f3c5-70d4-4faf-a4a5-ff9662d5f714",
+              dpsRecallId = dpsRecallId,
             ),
             CourtAppearanceRecallMappingDto(
               nomisCourtAppearanceId = 102,
-              dpsRecallId = "dc71f3c5-70d4-4faf-a4a5-ff9662d5f714",
+              dpsRecallId = dpsRecallId,
             ),
           ),
         )
@@ -4663,14 +4666,24 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
           ),
         )
 
-        courtSentencingNomisApi.stubUpdateRecallSentences(OFFENDER_NO)
+        courtSentencingNomisApi.stubUpdateRecallSentences(
+          OFFENDER_NO,
+          UpdateRecallResponse(
+            updatedCourtEventIds = listOf(101),
+            deletedCourtEventIds = listOf(102),
+            createdCourtEventIds = listOf(103),
+          ),
+        )
+
+        courtSentencingMappingApi.stubUpdateAppearanceRecallMapping(recallId = dpsRecallId)
+
         publishRecallUpdatedDomainEvent(
           source = "DPS",
-          recallId = "dc71f3c5-70d4-4faf-a4a5-ff9662d5f714",
+          recallId = dpsRecallId,
           sentenceIds = listOf("9ee21616-bbe4-4adc-b05e-c6e2a6a67cfc", "7ed5c261-9644-4516-9ab5-1b2cd48e6ca1"),
           previousSentenceIds = listOf("9ee21616-bbe4-4adc-b05e-c6e2a6a67cfc", "654212d8-4b58-4499-b465-73f9936999d9"),
         ).also {
-          waitForAnyProcessingToComplete()
+          waitForAnyProcessingToComplete("recall-updated-success")
         }
       }
 
@@ -4694,13 +4707,13 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
       @Test
       fun `will get breach appearanceIds related to recall`() {
         courtSentencingMappingApi.verify(
-          getRequestedFor(urlEqualTo("/mapping/court-sentencing/court-appearances/dps-recall-id/dc71f3c5-70d4-4faf-a4a5-ff9662d5f714")),
+          getRequestedFor(urlEqualTo("/mapping/court-sentencing/court-appearances/dps-recall-id/$dpsRecallId")),
         )
       }
 
       @Test
       fun `will retrieve DPS recall information`() {
-        courtSentencingApi.verify(getRequestedFor(urlEqualTo("/legacy/recall/dc71f3c5-70d4-4faf-a4a5-ff9662d5f714")))
+        courtSentencingApi.verify(getRequestedFor(urlEqualTo("/legacy/recall/$dpsRecallId")))
       }
 
       @Test
@@ -4747,6 +4760,30 @@ class CourtCasesToNomisIntTest : SqsIntegrationTestBase() {
             .withRequestBody(matchingJsonPath("beachCourtEventIds[0]", equalTo("101")))
             .withRequestBody(matchingJsonPath("beachCourtEventIds[1]", equalTo("102"))),
         )
+      }
+
+      @Test
+      fun `will update mapping for each breach appearance created and update for recall`() {
+        courtSentencingMappingApi.verify(
+          putRequestedFor(urlEqualTo("/mapping/court-sentencing/court-appearances/recall/$dpsRecallId"))
+            .withRequestBody(matchingJsonPath("nomisCourtAppearanceIds[0]", equalTo("101")))
+            .withRequestBody(matchingJsonPath("nomisCourtAppearanceIds[1]", equalTo("103"))),
+        )
+      }
+
+      @Test
+      fun `will send message to nomis migration to sync each breach hearing created`() {
+        await untilAsserted {
+          assertThat(fromNomisCourtSentencingQueue.countAllMessagesOnQueue()).isEqualTo(1)
+        }
+        val rawMessages = fromNomisCourtSentencingQueue.readAtMost10RawMessages()
+        val breachCreatedMessages = rawMessages.map { it.fromJson<SQSMessage>() }.filter { it.Type == "courtsentencing.resync.breach-court-appearance.inserted" }
+
+        with(breachCreatedMessages.first()) {
+          val request: SyncRecallBreachCourtAppearanceEvent = Message.fromJson()
+          assertThat(request.offenderNo).isEqualTo(OFFENDER_NO)
+          assertThat(request.courtAppearanceId).isEqualTo(103L)
+        }
       }
 
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingMappingApiMockServer.kt
@@ -331,6 +331,10 @@ class CourtSentencingMappingApiMockServer(private val jsonMapper: JsonMapper) {
     stubCreate("/mapping/court-sentencing/court-appearances/recall")
   }
 
+  fun stubUpdateAppearanceRecallMapping(recallId: String) {
+    stubPut("/mapping/court-sentencing/court-appearances/recall/$recallId")
+  }
+
   fun stubGetAppearanceRecallMappings(recallId: String, mappings: List<CourtAppearanceRecallMappingDto> = emptyList()) {
     stubGet(
       "/mapping/court-sentencing/court-appearances/dps-recall-id/$recallId",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingMappingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingMappingServiceTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.helpers.SpringAPIServiceTest
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtAppearanceRecallMappingsUpdateDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.CourtCaseBatchMappingDto
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomismappings.model.DpsCourtCaseBatchMappingDto
 
@@ -65,6 +66,25 @@ class CourtSentencingMappingServiceTest {
 
       courtCaseMappingApiMockServer.verify(
         postRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-cases/delete-by-dps-ids")).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+  }
+
+  @Nested
+  inner class UpdateAppearanceRecallMappings {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      courtCaseMappingApiMockServer.stubUpdateAppearanceRecallMapping("123")
+
+      apiService.updateAppearanceRecallMappings(
+        recallId = "123",
+        CourtAppearanceRecallMappingsUpdateDto(
+          nomisCourtAppearanceIds = emptyList(),
+        ),
+      )
+
+      courtCaseMappingApiMockServer.verify(
+        putRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/recall/123")).withHeader("Authorization", equalTo("Bearer ABCDE")),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/courtsentencing/CourtSentencingNomisApiMockServer.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.Of
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.OffenderChargeRepairRequest
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.SentenceResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateCourtAppearanceResponse
+import uk.gov.justice.digital.hmpps.prisonertonomisupdate.nomisprisoner.model.UpdateRecallResponse
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.wiremock.NomisApiExtension.Companion.nomisApi
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -239,12 +240,20 @@ class CourtSentencingNomisApiMockServer {
       ),
     )
   }
-  fun stubUpdateRecallSentences(offenderNo: String) {
+  fun stubUpdateRecallSentences(
+    offenderNo: String,
+    response: UpdateRecallResponse = UpdateRecallResponse(
+      createdCourtEventIds = emptyList(),
+      updatedCourtEventIds = emptyList(),
+      deletedCourtEventIds = emptyList(),
+    ),
+  ) {
     nomisApi.stubFor(
       put("/prisoners/$offenderNo/sentences/recall").willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withStatus(204),
+          .withStatus(200)
+          .withBody(jsonMapper.writeValueAsString(response)),
       ),
     )
   }


### PR DESCRIPTION
When a DPS recall is updated it may contain additional court cases. These will each be assigned a breach court appearance, so this changes ensures the mapping between the recall id and the hearings is correctly updated.

(always sends message back to migration service for the new court appearances for the sync back to DPS)