### PR TITLE
SDIT-3987 Ignore events where RaS own the data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/court/CourtSchedulerAppearanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/court/CourtSchedulerAppearanceService.kt
@@ -16,6 +16,13 @@ import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.createMapping
 import uk.gov.justice.digital.hmpps.prisonertonomisupdate.services.track
 import java.util.*
 
+// These events are ignored if there is a RaS external reference on the event (we expect this to be true for all events soon)
+val ignoreSentencingEvents = listOf(
+  "person.court-appearance.scheduled",
+  "person.court-appearance.recorded",
+  "person.court-appearance.cancelled",
+)
+
 @Service
 class CourtSchedulerAppearanceService(
   private val mappingApi: CourtSchedulerMappingApiService,
@@ -36,13 +43,15 @@ class CourtSchedulerAppearanceService(
   suspend fun courtAppearanceChanged(event: CourtSchedulerEvent) {
     val prisonerNumber = event.personReference.prisonerNumber()
     val dpsCourtAppearanceId = event.additionalInformation.id
+    val externalReference = event.additionalInformation.externalReferenceUrn
     val telemetryMap = mutableMapOf(
       "offenderNo" to prisonerNumber,
       "dpsCourtAppearanceId" to dpsCourtAppearanceId.toString(),
+      "externalReferenceUrn" to externalReference.toString(),
     )
     var telemetryKey = TELEMETRY_KEY_CREATE
 
-    if (event.additionalInformation.source != "DPS") {
+    if (event.additionalInformation.source != "DPS" || shouldIgnoreSentencingEvent(externalReference, event.eventType)) {
       telemetryClient.trackEvent("$telemetryKey-ignored", telemetryMap)
       return
     }
@@ -73,12 +82,14 @@ class CourtSchedulerAppearanceService(
   suspend fun courtAppearanceDeleted(event: CourtSchedulerEvent) {
     val prisonerNumber = event.personReference.prisonerNumber()
     val dpsCourtAppearanceId = event.additionalInformation.id
+    val externalReference = event.additionalInformation.externalReferenceUrn
     val telemetryMap = mutableMapOf(
       "offenderNo" to prisonerNumber,
       "dpsCourtAppearanceId" to dpsCourtAppearanceId.toString(),
+      "externalReferenceUrn" to externalReference.toString(),
     )
 
-    if (event.additionalInformation.source != "DPS") {
+    if (event.additionalInformation.source != "DPS" || shouldIgnoreSentencingEvent(externalReference, event.eventType)) {
       telemetryClient.trackEvent("$TELEMETRY_KEY_DELETE-ignored", telemetryMap)
       return
     }
@@ -150,3 +161,5 @@ fun String.toNomisSchedulesStatus(external: Boolean) = when {
 }
 
 class CourtSchedulerSyncException(message: String) : RuntimeException(message)
+
+private fun shouldIgnoreSentencingEvent(externalReferenceUrn: String?, eventType: String): Boolean = ignoreSentencingEvents.contains(eventType) && externalReferenceUrn != null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/court/CourtSchedulerDomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/court/CourtSchedulerDomainEventListener.kt
@@ -63,6 +63,7 @@ data class CourtSchedulerEvent(
 data class CourtSchedulerAdditionalInformation(
   val id: UUID,
   val source: String,
+  val externalReferenceUrn: String? = null,
 )
 
 data class PersonReference(val identifiers: List<Identifier> = listOf()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/court/CourtSchedulerScheduleIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertonomisupdate/movements/court/CourtSchedulerScheduleIntTest.kt
@@ -299,6 +299,55 @@ class CourtSchedulerScheduleIntTest(
           )
         }
       }
+
+      @Nested
+      inner class WhenUpdateComesFromSentencing {
+
+        @BeforeEach
+        fun setUp() {
+          mappingApi.stubGetCourtScheduleMapping(status = NOT_FOUND)
+          dpsApi.stubGetCourtAppearance(id = dpsCourtAppearanceId, startTime = startTime)
+          nomisApi.stubUpsertCourtScheduleOut(response = UpsertCourtScheduleOutResponse(12345L, nomisEventId))
+          mappingApi.stubCreateCourtScheduleMapping()
+
+          publishCourtAppearanceDomainEvent(
+            dpsId = dpsCourtAppearanceId,
+            prisonerNumber = "A1234BC",
+            eventType = "person.court-appearance.scheduled",
+            externalReferenceExists = true,
+          )
+          waitForAnyProcessingToComplete("court-scheduler-schedule-create-ignored")
+        }
+
+        @Test
+        fun `will not check for existing mapping`() {
+          mappingApi.verify(
+            count = 0,
+            getRequestedFor(urlEqualTo("/mapping/court-scheduler/schedule/dps-id/$dpsCourtAppearanceId")),
+          )
+        }
+
+        @Test
+        fun `will not upsert NOMIS court schedule`() {
+          nomisApi.verify(
+            count = 0,
+            putRequestedFor(urlEqualTo("/movements/A1234BC/court/schedule/out")),
+          )
+        }
+
+        @Test
+        fun `will publish ignored telemetry`() {
+          verify(telemetryClient).trackEvent(
+            eq("court-scheduler-schedule-create-ignored"),
+            check {
+              assertThat(it).containsEntry("dpsCourtAppearanceId", "$dpsCourtAppearanceId")
+              assertThat(it).containsEntry("offenderNo", prisonerNumber)
+              assertThat(it).containsEntry("externalReferenceUrn", "some-ext-ref")
+            },
+            isNull(),
+          )
+        }
+      }
     }
 
     @Nested
@@ -345,8 +394,8 @@ class CourtSchedulerScheduleIntTest(
       nomisApi.stubDeleteCourtScheduleOut(prisonerNumber, nomisEventId)
     }
 
-    private fun publishDeleteEvent(source: String = "DPS", completedTelemetry: String? = null) {
-      publishCourtAppearanceDomainEvent(dpsCourtAppearanceId, prisonerNumber, source, "person.court-appearance.cancelled")
+    private fun publishDeleteEvent(source: String = "DPS", completedTelemetry: String? = null, externalReferenceExists: Boolean = false) {
+      publishCourtAppearanceDomainEvent(dpsCourtAppearanceId, prisonerNumber, source, "person.court-appearance.cancelled", externalReferenceExists)
       if (completedTelemetry == null) {
         waitForAnyProcessingToComplete()
       } else {
@@ -431,11 +480,31 @@ class CourtSchedulerScheduleIntTest(
         isNull(),
       )
     }
+
+    @Test
+    fun `should ignore if message has a sentencing external reference`() {
+      publishDeleteEvent(externalReferenceExists = true)
+
+      verify(telemetryClient).trackEvent(
+        eq("court-scheduler-schedule-delete-ignored"),
+        check {
+          assertThat(it).containsEntry("dpsCourtAppearanceId", dpsCourtAppearanceId.toString())
+          assertThat(it).containsEntry("offenderNo", prisonerNumber)
+        },
+        isNull(),
+      )
+    }
   }
 
-  private fun publishCourtAppearanceDomainEvent(dpsId: UUID, prisonerNumber: String, source: String = "DPS", eventType: String = "person.court-appearance.scheduled") {
+  private fun publishCourtAppearanceDomainEvent(
+    dpsId: UUID,
+    prisonerNumber: String,
+    source: String = "DPS",
+    eventType: String = "person.court-appearance.scheduled",
+    externalReferenceExists: Boolean = false,
+  ) {
     with(eventType) {
-      publishDomainEvent(eventType = this, payload = messagePayload(eventType = this, id = dpsId, prisonerNumber = prisonerNumber, source = source))
+      publishDomainEvent(eventType = this, payload = messagePayload(eventType = this, id = dpsId, prisonerNumber = prisonerNumber, source = source, externalReferenceExists = externalReferenceExists))
     }
   }
 
@@ -460,6 +529,7 @@ class CourtSchedulerScheduleIntTest(
     prisonerNumber: String,
     id: UUID,
     source: String,
+    externalReferenceExists: Boolean = false,
   ) = //language=JSON
     """
     {
@@ -468,6 +538,7 @@ class CourtSchedulerScheduleIntTest(
       "additionalInformation": {
         "id": "$id",
         "source": "$source"
+        ${if (externalReferenceExists) """, "externalReferenceUrn":"some-ext-ref"""" else "" }
       },
       "personReference": {
         "identifiers": [


### PR DESCRIPTION
Updates from remand and sentencing are sync'd directly to NOMIS and the court appearance scheduler. However we then receive an event from CAS with source=DPS - so we process that event.
We should ignore any events from CAS that have an external reference URN - that means that RaS own the data so we do nothing.
Note that we're not currently applying this to all events, but will do once all updates from RaS are handled directly by CAS.